### PR TITLE
[EBR2-99] Bundle Bootstrap CSS locally instead of the defunct StackPath CDN

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/hbp.png" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { CookiesProvider } from 'react-cookie';
+// Bundle Bootstrap's stylesheet locally: it used to load only from the defunct
+// StackPath CDN, which left the app unstyled. Imported before the local CSS so
+// application styles keep the upper hand.
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';


### PR DESCRIPTION
## Ticket
https://hbpneurorobotics.atlassian.net/browse/EBR2-99

## Problem
The app rendered unstyled: Bootstrap's stylesheet was loaded **only** from the
StackPath CDN (`stackpath.bootstrapcdn.com`) in `public/index.html`. StackPath's
BootstrapCDN was shut down, so the request fails and no Bootstrap styling loads.
`bootstrap@4.5` is already a direct dependency.

## Fix
- Remove the dead StackPath `<link ... bootstrap.min.css>` from `public/index.html`.
- `import 'bootstrap/dist/css/bootstrap.min.css';` in `src/index.js`, placed
  **before** the local `./index.css` so application styles keep precedence.

## Notes
- `public/index.html` contained no other dead-CDN `<link>`/`<script>` (no jQuery/Popper tags).
- Bootstrap **JS** is not needed: the UI uses `react-bootstrap` (React reimplementation
  of the widgets), which does not depend on the Bootstrap JS bundle or jQuery. Only the
  CSS was bundled; JS left untouched.

## Verification
- Production build via `node:18-alpine` + `NODE_OPTIONS=--openssl-legacy-provider`
  (matches the Dockerfile toolchain) succeeds. The vendor CSS chunk now embeds the
  "Bootstrap v4" stylesheet (grew ~160 KB) and the built `index.html` no longer
  references StackPath.
- `eslint src/index.js` clean.

> Build/test note: the local host runs Node 24, where CRA4/Webpack 4 cannot run
> (`--openssl-legacy-provider` is a no-op → `ERR_OSSL_EVP_UNSUPPORTED`). Validation
> was therefore run inside the repo's `node:18-alpine` toolchain, matching the Dockerfile.