### PR TITLE
[EBR2-100] Fix experiment-workbench state lockout on failed simulation transitions

### DIFF
--- a/src/components/experiment-workbench/experiment-workbench-service.js
+++ b/src/components/experiment-workbench/experiment-workbench-service.js
@@ -272,25 +272,9 @@ class ExperimentWorkbenchService extends EventEmitter {
    * @param {float}  msg.line_text is the text with the error
    */
   errorMsgHandler = (msg) => {
+    let msgObj;
     try {
-      const msgObj = JSON.parse(msg);
-      const err = {
-        message: msgObj.msg,
-        code: msgObj.error_type,
-        stack: `${msgObj.fileName}:${msgObj.line_number}:${msgObj.line_text}\n`
-      };
-      DialogService.instance.simulationError(err);
-
-      // A `Loading` error is non-recoverable (the backend's only remaining
-      // action is shutdown()), so move the experiment card into a failed
-      // state instead of leaving it in its last-known state (EBR2-89).
-      if (msgObj.error_type === 'Loading') {
-        this.simulationState = EXPERIMENT_STATE.FAILED;
-        ExperimentWorkbenchService.instance.emit(
-          ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
-          { state: EXPERIMENT_STATE.FAILED }
-        );
-      }
+      msgObj = JSON.parse(msg);
     }
     catch (err) {
       // Never swallow the failure: if the payload can't be parsed, still tell
@@ -299,6 +283,45 @@ class ExperimentWorkbenchService extends EventEmitter {
         message: 'Could not parse the error MQTT message:\n' + msg.toString(),
         data: err.toString()
       });
+      return;
+    }
+
+    DialogService.instance.simulationError({
+      message: msgObj.msg,
+      code: msgObj.error_type,
+      stack: `${msgObj.fileName}:${msgObj.line_number}:${msgObj.line_text}\n`
+    });
+
+    // A `Loading` error is non-recoverable (the backend's only remaining
+    // action is shutdown()), so move the experiment card into a failed
+    // state instead of leaving it in its last-known state (EBR2-89).
+    //
+    // Guard this branch on its own: a partial status payload used to make
+    // ExperimentTimeBox throw while reading undefined time fields, which
+    // aborted the synchronous emit and defeated the FAILED handling (it even
+    // got misreported as a parse error above). Emit a complete status object
+    // with zeroed times so every SIMULATION_STATUS_UPDATED listener runs
+    // cleanly, and contain any remaining listener error (EBR2-100).
+    if (msgObj.error_type === 'Loading') {
+      this.simulationState = EXPERIMENT_STATE.FAILED;
+      try {
+        ExperimentWorkbenchService.instance.emit(
+          ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
+          {
+            state: EXPERIMENT_STATE.FAILED,
+            realTime: 0,
+            simulationTime: 0,
+            simulationTimeLeft: 0
+          }
+        );
+      }
+      catch (emitErr) {
+        // A misbehaving status listener must not mask the simulation failure.
+        DialogService.instance.unexpectedError({
+          message: 'Failed to propagate the failed simulation state.',
+          data: emitErr.toString()
+        });
+      }
     }
   }
 

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -480,7 +480,7 @@ class ExperimentWorkbench extends React.Component {
               color={
                 this.state.availableServers.length && ExperimentWorkbenchService.instance.mqttConnected()
                   ? 'inherit'
-                  : 'dark'
+                  : 'default'
               }
               className={classes.controlButton}
               onClick={() => this.onButtonInitialize()}

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -400,21 +400,35 @@ class ExperimentWorkbench extends React.Component {
   async setSimulationState(newState) {
     if (this.state.runningSimulationID !== undefined) {
       this.setState({ simStateLoading: true });
-      await SimulationService.instance.updateState(
-        ExperimentWorkbenchService.instance.serverURL,
-        this.state.runningSimulationID,
-        newState
-      ).then((simInfo) => {
+      try {
+        const simInfo = await SimulationService.instance.updateState(
+          ExperimentWorkbenchService.instance.serverURL,
+          this.state.runningSimulationID,
+          newState
+        );
         console.debug('New simulation state is set: ' + simInfo.state);
         // Set STOPPED state by response (the other by MQTT)
         if (simInfo.state === EXPERIMENT_STATE.STOPPED) {
           this.setState({ simulationState: simInfo.state });
-          this.setState({ simStateLoading: false });
           // clear simulationInfo for the finilized experiments
           ExperimentWorkbenchService.instance.simulationInfo = undefined;
           this.setState({ runningSimulationID: undefined });
         }
-      });
+      }
+      catch (error) {
+        // A failed START/PAUSE/STOP must not leave the toolbar frozen with the
+        // spinner on and every control disabled forever: reflect a failed state
+        // and surface the error instead of a silent, permanent lockout.
+        this.setState({ simulationState: EXPERIMENT_STATE.FAILED });
+        DialogService.instance.simulationError({
+          message: 'Could not change the simulation state to "' + newState + '".',
+          data: error && error.toString()
+        });
+      }
+      finally {
+        // Always clear the loading flag so the toolbar becomes interactive again.
+        this.setState({ simStateLoading: false });
+      }
     }
   }
 


### PR DESCRIPTION
## Ticket
https://hbpneurorobotics.atlassian.net/browse/EBR2-100

## Problems & fixes

### 1. Toolbar frozen after a failed START/PAUSE/STOP (`experiment-workbench.js`)
`setSimulationState()` only cleared `simStateLoading` on a `STOPPED` response and
had no error handling. A rejected state-change request left the spinner on and
every toolbar control disabled **forever**.
Fix: wrap the update in `try/catch/finally` — always clear `simStateLoading` in
`finally`; on failure reflect a `FAILED` state and raise
`DialogService.simulationError(...)` so the user sees the failure instead of a
frozen toolbar.

### 2. Invalid MUI IconButton color (`experiment-workbench.js`)
The Initialize button passed `color='dark'`. MUI v4 `IconButton` only accepts
`default|inherit|primary|secondary`, so the value was ignored (console warning).
Fix: use the valid `'default'`.

### 3. `Loading` error defeated the FAILED handling (`experiment-workbench-service.js`)
`errorMsgHandler` emitted a partial status `{ state: FAILED }` for a
non-recoverable `Loading` error. `ExperimentTimeBox`'s `SIMULATION_STATUS_UPDATED`
listener then threw while reading undefined time fields
(`status.realTime.toString()` …). Because `EventEmitter.emit` is synchronous,
that throw aborted the emit (later listeners — including the workbench's own
`updateSimulationStatus` — never ran) and was **misreported as a JSON parse
error** by the surrounding `catch`.
Fix: parse in its own `try/catch`; handle the `Loading → FAILED` transition in a
separate guarded block that emits a complete status object (zeroed
`realTime`/`simulationTime`/`simulationTimeLeft`) so every listener runs cleanly,
and contains any residual listener error.

## Commits (atomic)
- `[EBR2-100] Always clear workbench loading flag and surface failed state changes`
- `[EBR2-100] Use a valid MUI color for the Initialize IconButton`
- `[EBR2-100] Guard the Loading simulation error so the FAILED handler runs`

## Verification
- Production build via `node:18-alpine` + `NODE_OPTIONS=--openssl-legacy-provider`
  (matches the Dockerfile) compiles (pre-existing warnings only).
- `eslint` clean on the changed files (only a pre-existing `jspb` unused-import
  warning remains, unrelated to this change). No jest tests cover these modules.

> Build note: the local host runs Node 24, where CRA4/Webpack 4 cannot run
> (`ERR_OSSL_EVP_UNSUPPORTED`); validation used the repo's `node:18-alpine` toolchain.