### PR TITLE
[EBR2-101] Add app error boundary and loading states; fix listener leaks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
 
 import EntryPage from './components/entry-page/entry-page';
+import ErrorBoundary from './components/error-boundary/error-boundary';
 import ErrorDialog from './components/dialog/error-dialog.js';
 import ExperimentsOverview from './components/experiments-overview/experiments-overview';
 import ExperimentWorkbench from './components/experiment-workbench/experiment-workbench';
@@ -19,18 +20,20 @@ class App extends React.Component {
 
   render() {
     return (
-      <div>
-        <ErrorDialog />
-        <NotificationDialog/>
-        <BrowserRouter>
-          <Switch>
-            <Route path='/experiments-overview' render={() => (<ExperimentsOverview/>)} />
-            <Route path='/experiment/:experimentID' component={ExperimentWorkbench}/>
-            {/* <Route path='/simulation-view/:serverIP/:simulationID' component={SimulationView} /> */}
-            <Route path='/' render={() => (<EntryPage cookies={this.props.cookies}/>)} />
-          </Switch>
-        </BrowserRouter>
-      </div>
+      <ErrorBoundary>
+        <div>
+          <ErrorDialog />
+          <NotificationDialog/>
+          <BrowserRouter>
+            <Switch>
+              <Route path='/experiments-overview' render={() => (<ExperimentsOverview/>)} />
+              <Route path='/experiment/:experimentID' component={ExperimentWorkbench}/>
+              {/* <Route path='/simulation-view/:serverIP/:simulationID' component={SimulationView} /> */}
+              <Route path='/' render={() => (<EntryPage cookies={this.props.cookies}/>)} />
+            </Switch>
+          </BrowserRouter>
+        </div>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/components/entry-page/entry-page.js
+++ b/src/components/entry-page/entry-page.js
@@ -34,6 +34,15 @@ export default class EntryPage extends React.Component {
     );
   }
 
+  componentWillUnmount() {
+    // Remove the storage listener so the service does not call setState on an
+    // unmounted component (memory leak + React warning).
+    ExperimentStorageService.instance.removeListener(
+      ExperimentStorageService.EVENTS.UPDATE_EXPERIMENTS,
+      this.onUpdateStorageExperiments
+    );
+  }
+
   onUpdateStorageExperiments(storageExperiments) {
     this.getLastExperiments(storageExperiments);
   }

--- a/src/components/error-boundary/error-boundary.css
+++ b/src/components/error-boundary/error-boundary.css
@@ -1,0 +1,41 @@
+.error-boundary-fallback {
+  max-width: 640px;
+  margin: 10vh auto;
+  padding: 2rem;
+  text-align: center;
+  font-family: sans-serif;
+  color: #333;
+}
+
+.error-boundary-fallback h1 {
+  margin-bottom: 1rem;
+}
+
+.error-boundary-message {
+  margin: 1rem auto;
+  padding: 0.75rem 1rem;
+  max-width: 100%;
+  overflow-x: auto;
+  text-align: left;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #a00;
+}
+
+.error-boundary-reload {
+  margin-top: 1rem;
+  padding: 0.5rem 1.25rem;
+  font-size: 1rem;
+  cursor: pointer;
+  color: #fff;
+  background: #007bff;
+  border: none;
+  border-radius: 4px;
+}
+
+.error-boundary-reload:hover {
+  background: #0069d9;
+}

--- a/src/components/error-boundary/error-boundary.js
+++ b/src/components/error-boundary/error-boundary.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './error-boundary.css';
+
+/**
+ * Top-level React error boundary.
+ *
+ * Catches render/lifecycle errors thrown anywhere in the child tree and shows a
+ * friendly fallback instead of leaving the user with a blank white SPA. Without
+ * it, a single uncaught throw during render unmounts the whole application and
+ * nothing is displayed.
+ */
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: undefined };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Render the fallback UI on the next render.
+    return { hasError: true, error: error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Keep the details in the console for debugging; the UI stays friendly.
+    console.error('Unhandled UI error caught by ErrorBoundary:', error, errorInfo);
+  }
+
+  handleReload() {
+    window.location.reload();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className='error-boundary-fallback'>
+          <h1>Something went wrong.</h1>
+          <p>
+            The Neurorobotics Platform frontend hit an unexpected error and could
+            not render this view.
+          </p>
+          {this.state.error && this.state.error.message
+            ? <pre className='error-boundary-message'>{this.state.error.message}</pre>
+            : null}
+          <button
+            className='error-boundary-reload'
+            onClick={() => this.handleReload()}
+          >
+            Reload the application
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node
+};

--- a/src/components/experiment-list/experiment-list.js
+++ b/src/components/experiment-list/experiment-list.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Spinner from 'react-bootstrap/Spinner';
 
 import ExperimentListElement from './experiment-list-element.js';
 
@@ -6,10 +7,27 @@ import './experiment-list.css';
 
 export default class ExperimentList extends React.Component {
   render() {
+    // Distinguish "still loading the first fetch" from "loaded, but empty".
+    // Showing the empty-list message before the initial request completes is
+    // misleading, so render a spinner until the fetch has returned.
+    let emptyContent;
+    if (this.props.isLoading) {
+      emptyContent = (
+        <div className='no-items-notification'>
+          <Spinner animation='border' role='status' size='sm' /> Loading experiments ...
+        </div>
+      );
+    }
+    else {
+      emptyContent = (
+        <div className='no-items-notification'>List is currently empty ...</div>
+      );
+    }
+
     return (
       <div className='experiment-list-wrapper'>
         {this.props.experiments.length === 0 ?
-          <div className='no-items-notification'>List is currently empty ...</div> :
+          emptyContent :
           <ol>
             {this.props.experiments.map(experiment => {
               return (

--- a/src/components/experiments-overview/experiments-overview.js
+++ b/src/components/experiments-overview/experiments-overview.js
@@ -7,6 +7,7 @@ import PublicExperimentsService from '../../services/experiments/files/public-ex
 import ServerResourcesService from '../../services/experiments/execution/server-resources-service.js';
 import ExperimentExecutionService from '../../services/experiments/execution/experiment-execution-service.js';
 import RemoteExperimentFilesService from '../../services/experiments/files/remote-experiment-files-service.js';
+import DialogService from '../../services/dialog-service.js';
 
 import ImportExperimentButtons from '../experiment-list/import-experiment-buttons.js';
 import ExperimentList from '../experiment-list/experiment-list.js';
@@ -35,7 +36,11 @@ export default class ExperimentsOverview extends React.Component {
       joinableExperiments: [],
       availableServers: [],
       startingExperiment: undefined,
-      selectedTabIndex: ExperimentsOverview.CONSTANTS.TAB_INDEX.MY_EXPERIMENTS
+      selectedTabIndex: ExperimentsOverview.CONSTANTS.TAB_INDEX.MY_EXPERIMENTS,
+      // Starts loading; cleared on the first UPDATE_EXPERIMENTS event or on
+      // error, so the list shows a spinner instead of "empty" during the
+      // initial fetch.
+      isLoadingExperiments: true
     };
   }
 
@@ -63,6 +68,14 @@ export default class ExperimentsOverview extends React.Component {
       PublicExperimentsService.EVENTS.UPDATE_EXPERIMENTS,
       this.onUpdatePublicExperiments
     );
+
+    // Stop the loading spinner on errors too: the failed fetch is already
+    // surfaced by the dialog service, so we just clear the loading flag.
+    this.onDialogError = this.onDialogError.bind(this);
+    DialogService.instance.addListener(
+      DialogService.EVENTS.ERROR,
+      this.onDialogError
+    );
   }
 
   componentWillUnmount() {
@@ -85,6 +98,11 @@ export default class ExperimentsOverview extends React.Component {
       PublicExperimentsService.EVENTS.UPDATE_EXPERIMENTS,
       this.onUpdatePublicExperiments
     );
+
+    DialogService.instance.removeListener(
+      DialogService.EVENTS.ERROR,
+      this.onDialogError
+    );
   }
 
   onUpdateServerAvailability(availableServers) {
@@ -101,8 +119,14 @@ export default class ExperimentsOverview extends React.Component {
 
     this.setState({
       storageExperiments: storageExperiments,
-      joinableExperiments: joinableExperiments
+      joinableExperiments: joinableExperiments,
+      isLoadingExperiments: false
     });
+  }
+
+  onDialogError() {
+    // The error itself is shown by the dialog service; just stop the spinner.
+    this.setState({ isLoadingExperiments: false });
   }
 
   onUpdatePublicExperiments(publicExperiments) {
@@ -143,6 +167,7 @@ export default class ExperimentsOverview extends React.Component {
             <ExperimentList experiments={this.state.storageExperiments}
               availableServers={this.state.availableServers}
               startingExperiment={this.state.startingExperiment}
+              isLoading={this.state.isLoadingExperiments}
               selectExperimentOverviewTab={(index) => this.setState({ selectedTabIndex: index })}
               templateTab = {false} />
           </TabPanel>
@@ -172,7 +197,8 @@ export default class ExperimentsOverview extends React.Component {
             <ExperimentList
               experiments={this.state.joinableExperiments}
               availableServers={this.state.availableServers}
-              startingExperiment={this.state.startingExperiment} />
+              startingExperiment={this.state.startingExperiment}
+              isLoading={this.state.isLoadingExperiments} />
           </TabPanel>
         </Tabs>
       </div>

--- a/src/components/xpra/xpra-view.js
+++ b/src/components/xpra/xpra-view.js
@@ -18,21 +18,34 @@ export default class XpraView extends React.Component {
     if (this.state.xpraUrls.length > 0) {
       this.state.currentUrl = this.state.xpraUrls[0];
     }
+  }
 
-    ExperimentWorkbenchService.instance.on(
+  componentDidMount() {
+    ExperimentWorkbenchService.instance.addListener(
       ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
-      (status) => {
-        this.simulationState = status.state;
-        if (status.state === EXPERIMENT_STATE.PAUSED || status.state === EXPERIMENT_STATE.STARTED) {
-          if (ExperimentWorkbenchService.instance.xpraUrls.length > 0) {
-            this.setState({
-              xpraUrls: ExperimentWorkbenchService.instance.xpraUrls,
-              currentUrl: ExperimentWorkbenchService.instance.xpraUrls[0]
-            });
-          }
-        }
-      }
+      this.onSimulationStatusUpdated
     );
+  }
+
+  componentWillUnmount() {
+    // Remove the status listener so the service does not call setState on an
+    // unmounted component (memory leak + React warning).
+    ExperimentWorkbenchService.instance.removeListener(
+      ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
+      this.onSimulationStatusUpdated
+    );
+  }
+
+  onSimulationStatusUpdated = (status) => {
+    this.simulationState = status.state;
+    if (status.state === EXPERIMENT_STATE.PAUSED || status.state === EXPERIMENT_STATE.STARTED) {
+      if (ExperimentWorkbenchService.instance.xpraUrls.length > 0) {
+        this.setState({
+          xpraUrls: ExperimentWorkbenchService.instance.xpraUrls,
+          currentUrl: ExperimentWorkbenchService.instance.xpraUrls[0]
+        });
+      }
+    }
   }
 
   onChangeSelectedXpraUrl(event) {


### PR DESCRIPTION
## Ticket
https://hbpneurorobotics.atlassian.net/browse/EBR2-101

## Changes

### 1. Top-level ErrorBoundary (`src/App.js` + new `src/components/error-boundary/`)
A render/lifecycle throw anywhere in the tree unmounted the whole SPA and left a
blank white page. Added a React `ErrorBoundary` (`getDerivedStateFromError` +
`componentDidCatch`) and wrapped the application tree in `App.js`, so failures
show a friendly fallback with a "Reload the application" action.

### 2. Loading vs empty distinction (`experiment-list.js`, `experiments-overview.js`)
The overview showed *"List is currently empty ..."* before the first fetch even
returned. Added an `isLoading` distinction:
- `ExperimentsOverview` starts in a loading state, cleared on the first
  `UPDATE_EXPERIMENTS` event **and** on error (the failure is already surfaced by
  `DialogService`, so we only clear the flag). The listener is registered in
  `componentDidMount` and removed in `componentWillUnmount`.
- The flag is threaded into the storage-backed `ExperimentList`s. While loading,
  the list renders a spinner ("Loading experiments ..."); the empty message only
  appears after a successful fetch returned zero items.

### 3. Listener cleanup on unmount (`entry-page.js`, `xpra-view.js`)
- `EntryPage` registered an `ExperimentStorageService.UPDATE_EXPERIMENTS` listener
  that was never removed — added `componentWillUnmount` cleanup.
- `XpraView` registered a `SIMULATION_STATUS_UPDATED` listener via an inline arrow
  in the constructor (unremovable). Promoted it to a named method, moved
  registration to `componentDidMount`, and added `componentWillUnmount` cleanup.

Both fixes stop the listener leak and the `setState`-after-unmount warning.

## Commits (atomic)
- `[EBR2-101] Add a top-level ErrorBoundary around the app tree`
- `[EBR2-101] Distinguish loading from empty in the experiment lists`
- `[EBR2-101] Remove status listeners on unmount in entry page and xpra view`

## Verification
- Production build via `node:18-alpine` + `NODE_OPTIONS=--openssl-legacy-provider`
  (matches the Dockerfile) compiles (pre-existing warnings only).
- `eslint` clean on all changed/new files.
- Full jest suite green: 98 passed, 14 skipped, 0 failures.

> Build note: the local host runs Node 24, where CRA4/Webpack 4 cannot run
> (`ERR_OSSL_EVP_UNSUPPORTED`); validation used the repo's `node:18-alpine` toolchain.