### PR TITLE
[EBR2-61] Migrate react-router-dom v5 to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
         "react-icons": "4.1.0",
-        "react-router-dom": "5.2.0",
+        "react-router-dom": "^6",
         "react-tabs": "3.1.2",
         "roslib": "1.1.0",
         "rxjs": "6.6.3",
@@ -3980,6 +3980,15 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@restart/context": {
       "version": "2.1.4",
@@ -9694,20 +9703,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -13523,21 +13518,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -15143,64 +15123,36 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-tabs": {
       "version": "3.1.2",
@@ -15465,12 +15417,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
@@ -16837,12 +16783,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -17417,12 +17357,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-icons": "4.1.0",
-    "react-router-dom": "5.2.0",
+    "react-router-dom": "^6",
     "react-tabs": "3.1.2",
     "roslib": "1.1.0",
     "rxjs": "6.6.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
 
 import EntryPage from './components/entry-page/entry-page';
@@ -25,12 +25,14 @@ class App extends React.Component {
           <ErrorDialog />
           <NotificationDialog/>
           <BrowserRouter>
-            <Switch>
-              <Route path='/experiments-overview' render={() => (<ExperimentsOverview/>)} />
-              <Route path='/experiment/:experimentID' component={ExperimentWorkbench}/>
-              {/* <Route path='/simulation-view/:serverIP/:simulationID' component={SimulationView} /> */}
-              <Route path='/' render={() => (<EntryPage cookies={this.props.cookies}/>)} />
-            </Switch>
+            <Routes>
+              <Route path='/experiments-overview' element={<ExperimentsOverview/>} />
+              <Route path='/experiment/:experimentID' element={<ExperimentWorkbench/>} />
+              {/* <Route path='/simulation-view/:serverIP/:simulationID' element={<SimulationView/>} /> */}
+              {/* Catch-all keeps the v5 behaviour where the non-exact '/' route
+                  rendered the entry page for the root and any unmatched path. */}
+              <Route path='*' element={<EntryPage cookies={this.props.cookies}/>} />
+            </Routes>
           </BrowserRouter>
         </div>
       </ErrorBoundary>

--- a/src/components/experiment-list/experiment-list-element.js
+++ b/src/components/experiment-list/experiment-list-element.js
@@ -1,6 +1,5 @@
 import React from 'react';
-// import { Link, useHistory } from 'react-router-dom';
-import { withRouter } from 'react-router-dom';
+import withRouter from '../../utility/with-router';
 import { FaTrash, FaFileExport, FaShareAlt, FaClone } from 'react-icons/fa';
 // import { MdOutlineDownloadDone } from 'react-icons/md';
 // import { RiPlayFill, RiPlayLine, RiPlayList2Fill } from 'react-icons/ri';
@@ -68,9 +67,7 @@ class ExperimentListElement extends React.Component {
   }
 
   openExperimentWorkbench = (expID) => {
-    this.props.history.push({
-      pathname: '/experiment/' + expID
-    });
+    this.props.navigate('/experiment/' + expID);
   }
 
   getAvailabilityInfo() {

--- a/src/components/experiment-list/simulation-details.js
+++ b/src/components/experiment-list/simulation-details.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FaStop } from 'react-icons/fa';
 import { ImEnter } from 'react-icons/im';
-import { withRouter } from 'react-router-dom';
+import withRouter from '../../utility/with-router';
 
 import timeDDHHMMSS from '../../utility/time-filter.js';
 import { EXPERIMENT_STATE } from '../../services/experiments/experiment-constants.js';
@@ -59,9 +59,7 @@ class SimulationDetails extends React.Component {
     };
     ServerResourcesService.instance.getServerConfig(simulationInfo.server).then((serverConfig) => {
       ExperimentWorkbenchService.instance.serverURL = serverConfig['nrp-services'];
-      this.props.history.push({
-        pathname: '/experiment/' + simulationInfo.runningSimulation.experimentID
-      });
+      this.props.navigate('/experiment/' + simulationInfo.runningSimulation.experimentID);
     });
   }
 

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -3,6 +3,7 @@ import FlexLayout from 'flexlayout-react';
 
 import { withCookies } from 'react-cookie';
 
+import withRouter from '../../utility/with-router';
 import ExperimentTools from './experiment-tools';
 import ExperimentToolsService from './experiment-tools-service';
 import ExperimentWorkbenchService from './experiment-workbench-service';
@@ -176,7 +177,7 @@ class ExperimentWorkbench extends React.Component {
   constructor(props) {
     super(props);
 
-    const {experimentID} = props.match.params;
+    const {experimentID} = props.params;
     this.experimentID = experimentID;
     ExperimentWorkbenchService.instance.experimentID = this.experimentID;
     this.serverURL = ExperimentWorkbenchService.instance.serverURL;
@@ -442,9 +443,7 @@ class ExperimentWorkbench extends React.Component {
   }
 
   leaveWorkbench() {
-    this.props.history.push({
-      pathname: '/experiments-overview'
-    });
+    this.props.navigate('/experiments-overview');
   }
 
   getStatusStyle() {
@@ -638,7 +637,7 @@ ExperimentWorkbench.propTypes = {
   classes: PropTypes.object.isRequired
 };
 
-export default withCookies(withStyles(useStyles)(ExperimentWorkbench));
+export default withRouter(withCookies(withStyles(useStyles)(ExperimentWorkbench)));
 
 ExperimentWorkbench.CONSTANTS = Object.freeze({
   INTERVAL_INTERNAL_UPDATE_MS: 1000

--- a/src/utility/with-router.js
+++ b/src/utility/with-router.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+
+/**
+ * Compatibility shim for react-router v5's `withRouter` HOC, which was removed
+ * in react-router v6. It injects the v6 router hooks as props so existing class
+ * components keep working without being rewritten as function components.
+ *
+ * Injected props:
+ *   - `navigate` — replaces the old `history` object:
+ *       history.push(path)        -> navigate(path)
+ *       history.replace(path)     -> navigate(path, { replace: true })
+ *       history.goBack()          -> navigate(-1)
+ *   - `location` — same shape as before (from `useLocation`)
+ *   - `params` — route params (from `useParams`, was `match.params` in v5)
+ *
+ * @param {React.ComponentType} Component the component to wrap
+ * @returns {React.ComponentType} the wrapped component receiving router props
+ */
+export default function withRouter(Component) {
+  function ComponentWithRouterProp(props) {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const params = useParams();
+    return (
+      <Component
+        {...props}
+        navigate={navigate}
+        location={location}
+        params={params}
+      />
+    );
+  }
+  return ComponentWithRouterProp;
+}


### PR DESCRIPTION
Migrates the frontend from **react-router-dom v5 to v6**. Tracking issue: https://hbpneurorobotics.atlassian.net/browse/EBR2-61

Mechanical API migration only — all routes, paths, and navigation behaviour are preserved. Builds on the Vite (EBR2-59) and React 18 (EBR2-60) work already on `development`.

### Converted patterns
- **Dependency**: `react-router-dom` `5.2.0` → `^6` (resolves to `6.30.4`); v5-only transitive deps (`history` v4, etc.) drop from the lockfile.
- **`<Switch>` → `<Routes>`** (`src/App.js`).
- **`<Route component={X}>` / `render={() => <X/>}` → `<Route element={<X/>}>`** for all three routes.
- **Non-exact matching dropped** (v6 matches exactly by default). The former last, non-exact `<Route path='/'>` — which acted as a fall-through catch-all in the v5 `<Switch>` — becomes `<Route path='*'>` so the entry page still renders for `/` and any unmatched path.
- **`withRouter` HOC (removed in v6)** → new compatibility shim `src/utility/with-router.js` that injects `useNavigate` / `useLocation` / `useParams` as props (`navigate`, `location`, `params`), so the existing class components need no rewrite.
- **`history.push({ pathname })` → `navigate(path)`** in `simulation-details.js`, `experiment-list-element.js`, and `experiment-workbench.js`.
- **`props.match.params` → `props.params`** in `experiment-workbench.js`; it is rendered via `element={<.../>}` so it is wrapped with the shim to receive `experimentID` and `navigate`.
- `<Link>` usages (`entry-page.js`, `nrp-header.js`) are unchanged — still valid in v6. No `NavLink`/`activeClassName` in use.

### Verification (Docker `node:20`, `.npmrc` legacy-peer-deps honoured)
- `npm install` — OK (react-router-dom 6.30.4 installed; lockfile updated).
- `npm run build` (Vite 5) — **succeeds**, `✓ built`.
- `npx jest --ci` — **98 passed, 14 skipped, 112 total** (12 suites passed, 3 skipped).
- `eslint` on all changed files — clean.

### Out of scope (separate tickets)
- Material-UI v4 stays (EBR2-62).
- Bootstrap 4 stays (EBR2-63).
- React 18 is already in (EBR2-60).