### PR TITLE
[EBR2-108] Fix service-layer robustness bugs (error handling, caching, reconnect)

### DIFF
--- a/src/services/__tests__/authentication-service.test.js
+++ b/src/services/__tests__/authentication-service.test.js
@@ -97,4 +97,16 @@ describe('AuthenticationService', () => {
     spyAuthCollab.mockReturnValue(Promise.reject());
     await expect(AuthenticationService.instance.authenticate({force: true})).rejects.toBe(undefined);
   });
+
+  test('logout() (Collab mode) calls keycloak.logout and clears the local token', () => {
+    AuthenticationService.instance.oidcEnabled = true;
+    const logoutFn = jest.fn();
+    AuthenticationService.instance.keycloakClient = { authenticated: true, logout: logoutFn };
+    const clearSpy = jest.spyOn(AuthenticationService.instance, 'clearStoredLocalToken');
+
+    // Must not throw (previously called a nonexistent Keycloak method).
+    expect(() => AuthenticationService.instance.logout()).not.toThrow();
+    expect(clearSpy).toHaveBeenCalled();
+    expect(logoutFn).toHaveBeenCalled();
+  });
 });

--- a/src/services/__tests__/authentication-service.test.js
+++ b/src/services/__tests__/authentication-service.test.js
@@ -98,6 +98,25 @@ describe('AuthenticationService', () => {
     await expect(AuthenticationService.instance.authenticate({force: true})).rejects.toBe(undefined);
   });
 
+  test('getToken() (Collab mode) awaits the refresh and returns the fresh token', async () => {
+    AuthenticationService.instance.oidcEnabled = true;
+    // The refreshed token only becomes available once updateToken() resolves.
+    // A fire-and-forget refresh would return the stale token instead.
+    const keycloakClient = {
+      token: 'stale-token',
+      updateToken: jest.fn(() =>
+        Promise.resolve(true).then(() => {
+          keycloakClient.token = 'fresh-token';
+          return true;
+        }))
+    };
+    AuthenticationService.instance.keycloakClient = keycloakClient;
+
+    const token = await AuthenticationService.instance.getToken();
+    expect(keycloakClient.updateToken).toHaveBeenCalledWith(30);
+    expect(token).toBe('fresh-token');
+  });
+
   test('logout() (Collab mode) calls keycloak.logout and clears the local token', () => {
     AuthenticationService.instance.oidcEnabled = true;
     const logoutFn = jest.fn();

--- a/src/services/__tests__/mqtt-client-service.test.js
+++ b/src/services/__tests__/mqtt-client-service.test.js
@@ -92,4 +92,39 @@ describe('MqttClientService', () => {
     expect(sub2Token.callback).toHaveBeenCalledTimes(2);
     expect(sub3Token.callback).toHaveBeenCalledTimes(3);
   });
+
+  // EBR2-108: connection loss must be detected and surfaced so the UI can react.
+  test('tracks connection state and surfaces connection loss', () => {
+    const service = MqttClientService.instance;
+    const client = service.client; // mocked EventEmitter
+
+    const onDisconnected = jest.fn();
+    const onReconnecting = jest.fn();
+    const onStateChanged = jest.fn();
+    service.on(MqttClientService.EVENTS.DISCONNECTED, onDisconnected);
+    service.on(MqttClientService.EVENTS.RECONNECTING, onReconnecting);
+    service.on(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, onStateChanged);
+
+    client.emit('connect');
+    expect(service.isConnected()).toBe(true);
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.CONNECTED);
+
+    // A close after being connected is a real connection loss.
+    client.emit('close');
+    expect(service.isConnected()).toBe(false);
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.DISCONNECTED);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+
+    // Reconnect attempts are tracked and surfaced.
+    client.emit('reconnect');
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.RECONNECTING);
+    expect(onReconnecting).toHaveBeenCalledTimes(1);
+
+    // connect -> close -> reconnect = 3 state transitions
+    expect(onStateChanged).toHaveBeenCalledTimes(3);
+
+    service.removeListener(MqttClientService.EVENTS.DISCONNECTED, onDisconnected);
+    service.removeListener(MqttClientService.EVENTS.RECONNECTING, onReconnecting);
+    service.removeListener(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, onStateChanged);
+  });
 });

--- a/src/services/__tests__/mqtt-client-service.test.js
+++ b/src/services/__tests__/mqtt-client-service.test.js
@@ -24,7 +24,10 @@ describe('MqttClientService', () => {
 
   let unsubscribeAndValidate = (token) => {
     MqttClientService.instance.unsubscribe(token);
-    expect(MqttClientService.instance.subTokensMap.get(token.topic).includes(token)).toBeFalsy();
+    // After unsubscribe the token must no longer be present. The map entry is
+    // deleted entirely once a topic has no subscribers left.
+    let remaining = MqttClientService.instance.subTokensMap.get(token.topic);
+    expect(remaining === undefined || !remaining.includes(token)).toBeTruthy();
   };
 
   test('sub/unsub', () => {
@@ -38,6 +41,11 @@ describe('MqttClientService', () => {
         // Your custom mock logic for the 'subscribe' function
         console.log(`Mocked subscribe function called with topic: ${topic}`);
         // You can customize the behavior or return value of the 'subscribe' function here
+      });
+      // Mock the 'unsubscribe' function so we can assert the broker subscription
+      // is actually cancelled when the last subscriber leaves.
+      mqttClient.unsubscribe = jest.fn().mockImplementation((topic, callback) => {
+        console.log(`Mocked unsubscribe function called with topic: ${topic}`);
       });
 
       return mqttClient;
@@ -53,6 +61,8 @@ describe('MqttClientService', () => {
     let sub3Callback = jest.fn();
     let sub3Token = subscribeTopicAndValidate(topicB, sub3Callback);
 
+    let client = MqttClientService.instance.client;
+
     expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(2);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
 
@@ -65,6 +75,8 @@ describe('MqttClientService', () => {
     unsubscribeAndValidate(sub1Token);
     expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(1);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
+    // topicA still has a subscriber, so the broker subscription must remain.
+    expect(client.unsubscribe).not.toHaveBeenCalled();
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});
@@ -73,8 +85,10 @@ describe('MqttClientService', () => {
     expect(sub3Token.callback).toHaveBeenCalledTimes(2);
 
     unsubscribeAndValidate(sub2Token);
-    expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(0);
+    // Last subscriber for topicA gone: map entry deleted and broker unsubscribed.
+    expect(MqttClientService.instance.subTokensMap.has(topicA)).toBe(false);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
+    expect(client.unsubscribe).toHaveBeenCalledWith(topicA, expect.any(Function));
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});
@@ -83,8 +97,9 @@ describe('MqttClientService', () => {
     expect(sub3Token.callback).toHaveBeenCalledTimes(3);
 
     unsubscribeAndValidate(sub3Token);
-    expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(0);
-    expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(0);
+    expect(MqttClientService.instance.subTokensMap.has(topicA)).toBe(false);
+    expect(MqttClientService.instance.subTokensMap.has(topicB)).toBe(false);
+    expect(client.unsubscribe).toHaveBeenCalledWith(topicB, expect.any(Function));
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});

--- a/src/services/__tests__/roslib-service.test.js
+++ b/src/services/__tests__/roslib-service.test.js
@@ -49,6 +49,18 @@ describe('RoslibService (EBR2-108)', () => {
     // still a single cache entry for the clean URL
     expect(RoslibService.instance.connections.size).toBe(1);
   });
+
+  test('createService uses the provided ROS service type, not the service name', () => {
+    const connection = {};
+    RoslibService.instance.createService(connection, '/my_service', 'my_pkg/MySrv', { extra: 1 });
+
+    expect(ROSLIB.Service).toHaveBeenCalledWith({
+      ros: connection,
+      name: '/my_service',
+      serviceType: 'my_pkg/MySrv',
+      extra: 1
+    });
+  });
 });
 
 describe.skip('RoslibService', () => {

--- a/src/services/__tests__/roslib-service.test.js
+++ b/src/services/__tests__/roslib-service.test.js
@@ -6,6 +6,50 @@ import 'jest-fetch-mock';
 
 import * as ROSLIB from 'roslib';
 import RoslibService from '../roslib-service';
+import AuthenticationService from '../authentication-service';
+
+// Auto-mock roslib so ROSLIB.Ros does not open a real socket (which crashes the
+// node test process — the reason the legacy suite below is skipped).
+jest.mock('roslib');
+
+// EBR2-108: the connection cache must be keyed by the clean URL (not a
+// token-bearing URL) and a refreshed auth token must produce a fresh
+// connection; createService must use a real ROS service type, not the name.
+describe('RoslibService (EBR2-108)', () => {
+  afterEach(() => {
+    // Drop cached connections so each test starts clean (singleton state).
+    RoslibService.instance.connections.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('caches connections by clean URL and reuses them for the same token', async () => {
+    jest.spyOn(AuthenticationService.instance, 'getToken').mockReturnValue('tok-1');
+
+    const c1 = await RoslibService.instance.getConnection('ws://ros');
+    const c2 = await RoslibService.instance.getConnection('ws://ros');
+
+    expect(c1).toBe(c2);
+    expect(ROSLIB.Ros).toHaveBeenCalledTimes(1);
+    // token baked into the connection URL, not into the cache key
+    expect(ROSLIB.Ros).toHaveBeenCalledWith({ url: 'ws://ros?token=tok-1' });
+    // the map key is the clean URL
+    expect(RoslibService.instance.connections.has('ws://ros')).toBe(true);
+  });
+
+  test('recreates the connection when the auth token changes', async () => {
+    const getTokenSpy = jest.spyOn(AuthenticationService.instance, 'getToken');
+
+    getTokenSpy.mockReturnValue('tok-A');
+    await RoslibService.instance.getConnection('ws://ros');
+    getTokenSpy.mockReturnValue('tok-B');
+    await RoslibService.instance.getConnection('ws://ros');
+
+    expect(ROSLIB.Ros).toHaveBeenCalledTimes(2);
+    expect(ROSLIB.Ros).toHaveBeenLastCalledWith({ url: 'ws://ros?token=tok-B' });
+    // still a single cache entry for the clean URL
+    expect(RoslibService.instance.connections.size).toBe(1);
+  });
+});
 
 describe.skip('RoslibService', () => {
   test('makes sure that invoking the constructor fails with the right message', () => {

--- a/src/services/authentication-service.js
+++ b/src/services/authentication-service.js
@@ -61,18 +61,20 @@ class AuthenticationService {
     return this.promiseInitialized;
   }
 
-  getToken() {
+  async getToken() {
     if (this.oidcEnabled) {
       if (this.keycloakClient && this.keycloakClient.token) {
-        this.keycloakClient
-          .updateToken(30).then(refreshed => {
-            if (refreshed) {
-              console.info('token refreshed');
-            }
-          })
-          .catch(() => {
-            console.error('Failed to refresh token');
-          });
+        // Await the refresh so callers get an up-to-date token. The previous
+        // fire-and-forget refresh returned the possibly-stale current token.
+        try {
+          const refreshed = await this.keycloakClient.updateToken(30);
+          if (refreshed) {
+            console.info('token refreshed');
+          }
+        }
+        catch (error) {
+          console.error('Failed to refresh token');
+        }
         return this.keycloakClient.token;
       }
       else {

--- a/src/services/authentication-service.js
+++ b/src/services/authentication-service.js
@@ -87,8 +87,11 @@ class AuthenticationService {
   logout() {
     if (this.oidcEnabled) {
       if (this.keycloakClient && this.keycloakClient.authenticated) {
-        this.keycloakClient.logout();
-        this.keycloakClient.clearStoredLocalToken();
+        // Clear our own stored token, then end the OIDC session. The previous
+        // code called this.keycloakClient.clearStoredLocalToken(), which is not
+        // a Keycloak method and threw, aborting the logout.
+        this.clearStoredLocalToken();
+        return this.keycloakClient.logout({ redirectUri: window.location.origin });
       }
       else {
         console.error('Client is not authenticated');

--- a/src/services/experiments/execution/__tests__/running-simulation-service.test.js
+++ b/src/services/experiments/execution/__tests__/running-simulation-service.test.js
@@ -132,3 +132,49 @@ describe.skip('RunningSimulationService', () => {
     expect(DialogService.instance.simulationError).toHaveBeenCalled();
   });
 });
+
+// EBR2-108: simulationReady used to poll forever after a creationUniqueID
+// mismatch (it rejected but kept re-scheduling) and had no upper bound. This
+// suite covers the bounded/bailout behavior. A tiny interval and small
+// maxAttempts keep the tests fast and deterministic.
+describe('RunningSimulationService.simulationReady bailouts (EBR2-108)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('rejects and stops polling on a creationUniqueID mismatch', async () => {
+    const getSpy = jest.spyOn(RunningSimulationService.instance, 'httpRequestGET')
+      .mockImplementation(() => Promise.resolve({
+        json: () => Promise.resolve([
+          { state: EXPERIMENT_STATE.PAUSED, creationUniqueID: 'real-id' }
+        ])
+      }));
+
+    await expect(
+      RunningSimulationService.instance.simulationReady(
+        'mock-server-url', 'wrong-id', { interval: 1, maxAttempts: 10 })
+    ).rejects.toThrow('creationUniqueID mismatch');
+
+    // A mismatch is terminal: the poll must not be re-scheduled.
+    const callsAfterReject = getSpy.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(getSpy.mock.calls.length).toBe(callsAfterReject);
+    expect(callsAfterReject).toBe(1);
+  });
+
+  test('rejects with a timeout after maxAttempts while stuck pending', async () => {
+    const getSpy = jest.spyOn(RunningSimulationService.instance, 'httpRequestGET')
+      .mockImplementation(() => Promise.resolve({
+        json: () => Promise.resolve([
+          { state: EXPERIMENT_STATE.CREATED, creationUniqueID: 'real-id' }
+        ])
+      }));
+
+    await expect(
+      RunningSimulationService.instance.simulationReady(
+        'mock-server-url', 'real-id', { interval: 1, maxAttempts: 3 })
+    ).rejects.toThrow('Timed out');
+
+    expect(getSpy.mock.calls.length).toBe(3);
+  });
+});

--- a/src/services/experiments/execution/__tests__/server-resources-service.test.js
+++ b/src/services/experiments/execution/__tests__/server-resources-service.test.js
@@ -72,7 +72,10 @@ describe('ModelsStorageService', () => {
     });
 
     jest.spyOn(DialogService.instance, 'networkError');
-    serverConfig = await ServerResourcesService.instance.getServerConfig('test-server-id');
+    // getServerConfig must reject on failure (not resolve with the error) so the
+    // launch flow does not proceed on garbage.
+    await expect(ServerResourcesService.instance.getServerConfig('test-server-id'))
+      .rejects.toMatchObject({ message: 'getServerConfig request rejected' });
     expect(DialogService.instance.networkError).toHaveBeenCalled();
   });
 

--- a/src/services/experiments/execution/running-simulation-service.js
+++ b/src/services/experiments/execution/running-simulation-service.js
@@ -6,6 +6,10 @@ let _instance = null;
 const SINGLETON_ENFORCER = Symbol();
 
 const INTERVAL_CHECK_SIMULATION_READY = 1000;
+// Upper bound on the number of polls before giving up, so simulationReady can
+// never spin forever (e.g. a server stuck in a pending state or a mismatching
+// creationUniqueID). ~60 polls * 1s ≈ 1 minute.
+const MAX_CHECK_SIMULATION_READY_ATTEMPTS = 60;
 
 /**
  * Service handling state and info of running simulations.
@@ -30,12 +34,18 @@ class SimulationService extends HttpService {
    * Check whether a simulation on a server is ready to be started.
    * @param {string} serverURL - URL of the server where simulation should be run
    * @param {string} creationUniqueID - Unique ID generated while trying to launch experiment
+   * @param {object} [options] - optional overrides ({ interval, maxAttempts }), mainly for testing
    * @returns {Promise} Whether simulation is ready to start
    */
-  simulationReady(serverURL, creationUniqueID) {
+  simulationReady(serverURL, creationUniqueID, options = {}) {
+    const interval = options.interval || INTERVAL_CHECK_SIMULATION_READY;
+    const maxAttempts = options.maxAttempts || MAX_CHECK_SIMULATION_READY_ATTEMPTS;
+
     return new Promise((resolve, reject) => {
+      let attempts = 0;
       let verifySimulation = () => {
         setTimeout(() => {
+          attempts++;
           this.httpRequestGET(serverURL + '/simulation')
             .then(async (reponse) => {
               let continueVerify = true;
@@ -51,7 +61,11 @@ class SimulationService extends HttpService {
                     resolve(simulations[last]);
                   }
                   else {
-                    reject();
+                    // A mismatching creationUniqueID means this is not our
+                    // simulation and it never will be. Stop polling and reject
+                    // instead of spinning forever.
+                    continueVerify = false;
+                    reject(new Error('Simulation creationUniqueID mismatch'));
                   }
                 }
                 else if (state === EXPERIMENT_STATE.HALTED || state === EXPERIMENT_STATE.FAILED) {
@@ -61,11 +75,16 @@ class SimulationService extends HttpService {
               }
 
               if (continueVerify) {
-                verifySimulation();
+                if (attempts >= maxAttempts) {
+                  reject(new Error('Timed out waiting for the simulation to become ready'));
+                }
+                else {
+                  verifySimulation();
+                }
               }
             })
             .catch(reject);
-        }, INTERVAL_CHECK_SIMULATION_READY);
+        }, interval);
       };
 
       verifySimulation();

--- a/src/services/experiments/execution/server-resources-service.js
+++ b/src/services/experiments/execution/server-resources-service.js
@@ -89,7 +89,10 @@ class ServerResourcesService extends HttpProxyService {
       .catch((error) => {
         error = error || { message: 'getServerConfig request rejected' };
         DialogService.instance.networkError(error);
-        return error;
+        // Reject instead of resolving with the error object: callers (e.g. the
+        // experiment launch flow) treat a resolved value as a valid server
+        // config and would otherwise proceed to launch on garbage.
+        return Promise.reject(error);
       });
   }
 }

--- a/src/services/experiments/files/__tests__/import-experiment-service.test.js
+++ b/src/services/experiments/files/__tests__/import-experiment-service.test.js
@@ -33,3 +33,23 @@ describe.skip('ImportExperimentService', () => {
       new Response(JSON.stringify(MockScanStorageResponse)))).toStrictEqual(scanStorageResponse);
   });
 });
+
+// EBR2-108: getImportZipResponses used `await responses.forEach(async ...)`,
+// which awaits forEach's undefined return, so the arrays were still empty when
+// returned and the confirmation dialog showed blank names.
+describe('ImportExperimentService.getImportZipResponses (EBR2-108)', () => {
+  test('surfaces the real file names in order without blanks', async () => {
+    const raw = [
+      { zipBaseFolderName: 'exp_a', destFolderName: 'dest_a', newName: 'Imported A' },
+      { zipBaseFolderName: 'exp_b', destFolderName: 'dest_b', newName: 'Imported B' }
+    ];
+    const responses = raw.map((r) => new Response(JSON.stringify(r)));
+
+    const result = await ImportExperimentService.instance.getImportZipResponses(responses);
+
+    expect(result.numberOfZips).toBe(2);
+    expect(result.zipBaseFolderName).toEqual(['exp_a', 'exp_b']);
+    expect(result.destFolderName).toEqual(['dest_a', 'dest_b']);
+    expect(result.newExpName).toEqual(['Imported A', 'Imported B']);
+  });
+});

--- a/src/services/experiments/files/import-experiment-service.js
+++ b/src/services/experiments/files/import-experiment-service.js
@@ -59,8 +59,12 @@ export default class ImportExperimentService extends HttpProxyService {
       newExpName: []
     };
     importZipResponses.numberOfZips = responses.length;
-    await responses.forEach(async response =>{
-      response = await response.json();
+    // Await every parsed body before returning. The previous `await
+    // responses.forEach(async ...)` awaited forEach's undefined return, so the
+    // arrays were still empty when returned and the confirmation showed blank
+    // names. Parse in order so names line up across the arrays.
+    const parsedResponses = await Promise.all(responses.map((response) => response.json()));
+    parsedResponses.forEach((response) => {
       importZipResponses['zipBaseFolderName'].push(response['zipBaseFolderName']);
       importZipResponses['destFolderName'].push(response['destFolderName']);
       importZipResponses['newExpName'].push(response['newName']);

--- a/src/services/http-service.js
+++ b/src/services/http-service.js
@@ -46,7 +46,7 @@ export class HttpService extends EventEmitter {
   async performRequest(url, options, data){
     // Add authorization headerasync (url)
     await AuthenticationService.instance.promiseInitialized;
-    let token = AuthenticationService.instance.getToken();
+    let token = await AuthenticationService.instance.getToken();
     options.headers.Authorization = 'Bearer ' + token;
     if (data) {
       options.body = data;

--- a/src/services/models/__tests__/models-storage-service.test.js
+++ b/src/services/models/__tests__/models-storage-service.test.js
@@ -52,6 +52,30 @@ describe('ModelsStorageService', () => {
     expect(response.type).toBe('robots');
   });
 
+  test('getTemplateModels caches per model type and bails on an invalid type', async () => {
+    let modelsService = ModelsStorageService.instance;
+    modelsService.modelsCache = new Map(); // clean cache (singleton)
+
+    // Invalid model type: bail out, show a data error, do NOT fetch.
+    jest.spyOn(DialogService.instance, 'dataError').mockImplementation();
+    const getSpy = jest.spyOn(modelsService, 'httpRequestGET');
+    let invalid = await modelsService.getTemplateModels(false, 'notAModel', false);
+    expect(invalid).toBeUndefined();
+    expect(DialogService.instance.dataError).toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+
+    // Fetch two distinct types; each is cached under its own key.
+    await modelsService.getTemplateModels(false, 'robots', false);
+    await modelsService.getTemplateModels(false, 'brains', false);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+
+    // A repeated request for a cached type is served from cache (no new fetch).
+    await modelsService.getTemplateModels(false, 'robots', false);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    expect(modelsService.modelsCache.has('template:robots')).toBe(true);
+    expect(modelsService.modelsCache.has('template:brains')).toBe(true);
+  });
+
   test('getCustomModelsByUser function', async () => {
 
     let modelsService = ModelsStorageService.instance;

--- a/src/services/models/models-storage-service.js
+++ b/src/services/models/models-storage-service.js
@@ -20,6 +20,9 @@ class ModelsStorageService extends HttpProxyService {
     if (enforcer !== SINGLETON_ENFORCER) {
       throw new Error('Use ' + this.constructor.name + '.instance');
     }
+    // Cache keyed by "<template|custom>:<modelType>" so different model types
+    // (and templates vs custom models) never overwrite each other.
+    this.modelsCache = new Map();
   }
 
   static get instance() {
@@ -42,27 +45,32 @@ class ModelsStorageService extends HttpProxyService {
    * @return models - the list of template models
    */
   async getTemplateModels(forceUpdate = false, modelType, allCustomModels = false) {
-    if (!this.models || forceUpdate) {
-      try {
-        this.verifyModelType(modelType);
-      }
-      catch (error) {
-        DialogService.instance.dataError(error);
-      }
-
-      try {
-        const modelsWithTypeURL = allCustomModels ?
-          `${allCustomModelsURL}/${modelType}` :
-          `${storageModelsURL}/${modelType}`;
-        this.models = await (await this.httpRequestGET(modelsWithTypeURL)).json();
-      }
-      catch (error) {
-        DialogService.instance.networkError(error);
-      }
-
+    // Bail out on an invalid model type instead of firing a request with a bad
+    // path (which previously kept fetching with the invalid modelType).
+    try {
+      this.verifyModelType(modelType);
+    }
+    catch (error) {
+      DialogService.instance.dataError(error);
+      return;
     }
 
-    return this.models;
+    const cacheKey = (allCustomModels ? 'custom:' : 'template:') + modelType;
+    if (!forceUpdate && this.modelsCache.has(cacheKey)) {
+      return this.modelsCache.get(cacheKey);
+    }
+
+    try {
+      const modelsWithTypeURL = allCustomModels ?
+        `${allCustomModelsURL}/${modelType}` :
+        `${storageModelsURL}/${modelType}`;
+      const models = await (await this.httpRequestGET(modelsWithTypeURL)).json();
+      this.modelsCache.set(cacheKey, models);
+      return models;
+    }
+    catch (error) {
+      DialogService.instance.networkError(error);
+    }
   }
 
   /**

--- a/src/services/mqtt-client-service.js
+++ b/src/services/mqtt-client-service.js
@@ -31,6 +31,7 @@ export default class MqttClientService extends EventEmitter {
     this.state = {
       isConnected: false
     };
+    this.connectionState = MqttClientService.CONNECTION_STATES.DISCONNECTED;
 
     this.subTokensMap = new Map();
 
@@ -51,7 +52,15 @@ export default class MqttClientService extends EventEmitter {
   }
 
   isConnected() {
-    return this.client.connected;
+    return this.connectionState === MqttClientService.CONNECTION_STATES.CONNECTED;
+  }
+
+  /**
+   * @returns {string} the current connection state, one of
+   * MqttClientService.CONNECTION_STATES.
+   */
+  getConnectionState() {
+    return this.connectionState;
   }
 
   getBrokerURL() {
@@ -65,27 +74,70 @@ export default class MqttClientService extends EventEmitter {
   connect() {
     console.info('MQTT connecting to ' + this.mqttBrokerUrl + ' ...');
     this.client = mqtt.connect(this.mqttBrokerUrl, { clientId: 'nrp-frontend_' + uuidv4() });
-    this.client.on('connect', () => {
-      this.onConnect();
-    });
-    this.client.on('error', this.onError);
-    // TODO: fetch disconnection event properly
-    this.client.on('disconnect', () => {
-      console.info('... MQTT disconnected');
-      this.emit(MqttClientService.EVENTS.DISCONNECTED);
-    });
+    // Track the full lifecycle so a lost connection is actually detected and
+    // surfaced (previously only 'connect' and a bare 'disconnect' were handled,
+    // so drops/offline/reconnect went unnoticed).
+    this.client.on('connect', () => this.onConnect());
+    this.client.on('reconnect', () => this.onReconnect());
+    this.client.on('close', () => this.onClose());
+    this.client.on('offline', () => this.onOffline());
+    this.client.on('error', (error) => this.onError(error));
+    this.client.on('disconnect', () => this.onDisconnect());
     this.client.on('message', (topic, message) => {
       this.onMessage(topic, message);
     });
   }
 
+  /**
+   * Update the tracked connection state and notify listeners. Emits a single
+   * DISCONNECTED event when an established connection is lost.
+   *
+   * @param {string} state one of MqttClientService.CONNECTION_STATES
+   */
+  setConnectionState(state) {
+    const previous = this.connectionState;
+    if (previous === state) {
+      return;
+    }
+    this.connectionState = state;
+    this.state.isConnected = (state === MqttClientService.CONNECTION_STATES.CONNECTED);
+    this.emit(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, state);
+    if (previous === MqttClientService.CONNECTION_STATES.CONNECTED &&
+      state !== MqttClientService.CONNECTION_STATES.CONNECTED) {
+      this.emit(MqttClientService.EVENTS.DISCONNECTED, state);
+    }
+  }
+
   onError(error) {
     console.error(error);
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.ERROR);
+    this.emit(MqttClientService.EVENTS.ERROR, error);
+  }
+
+  onReconnect() {
+    console.info('... MQTT reconnecting');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.RECONNECTING);
+    this.emit(MqttClientService.EVENTS.RECONNECTING);
+  }
+
+  onClose() {
+    console.info('... MQTT connection closed');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.DISCONNECTED);
+  }
+
+  onOffline() {
+    console.info('... MQTT offline');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.OFFLINE);
+  }
+
+  onDisconnect() {
+    console.info('... MQTT disconnected');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.DISCONNECTED);
   }
 
   onConnect() {
     console.info('... MQTT connected');
-    console.info(this.client);
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.CONNECTED);
     // TODO: filter nrp messages
     this.client.subscribe('#', (err) => {
       if (err) {
@@ -224,5 +276,16 @@ export default class MqttClientService extends EventEmitter {
 
 MqttClientService.EVENTS = Object.freeze({
   CONNECTED: 'CONNECTED',
-  DISCONNECTED: 'DISCONNECTED'
+  DISCONNECTED: 'DISCONNECTED',
+  RECONNECTING: 'RECONNECTING',
+  ERROR: 'ERROR',
+  CONNECTION_STATE_CHANGED: 'CONNECTION_STATE_CHANGED'
+});
+
+MqttClientService.CONNECTION_STATES = Object.freeze({
+  CONNECTED: 'connected',
+  RECONNECTING: 'reconnecting',
+  OFFLINE: 'offline',
+  DISCONNECTED: 'disconnected',
+  ERROR: 'error'
 });

--- a/src/services/mqtt-client-service.js
+++ b/src/services/mqtt-client-service.js
@@ -255,6 +255,19 @@ export default class MqttClientService extends EventEmitter {
       else {
         console.warn('Your provided token could not be found in the subscription list');
       }
+      // When the last subscriber for a topic is removed, actually cancel the
+      // broker subscription and drop the map entry, instead of leaving an
+      // empty array behind (which leaked entries and kept the broker sending).
+      if (tokens.length === 0) {
+        if (this.client && typeof this.client.unsubscribe === 'function') {
+          this.client.unsubscribe(unsubToken.topic, (err) => {
+            if (err) {
+              console.error(err);
+            }
+          });
+        }
+        this.subTokensMap.delete(unsubToken.topic);
+      }
     }
     else{
       console.warn('The topic ' + unsubToken.topic + ' was not found');

--- a/src/services/proxy/__tests__/http-proxy-service.test.js
+++ b/src/services/proxy/__tests__/http-proxy-service.test.js
@@ -3,7 +3,7 @@
 */
 import '@testing-library/jest-dom';
 
-import { HttpProxyService } from '../http-proxy-service';
+import { HttpProxyService, NRPProxyError } from '../http-proxy-service';
 import EventProxyService from '../event-proxy-service';
 jest.mock('../../authentication-service.js');
 
@@ -127,8 +127,12 @@ describe('HttpProxyService', () => {
     const emitDisconnectedSpy = jest.spyOn(EventProxyService.instance, 'emitDisconnected');
     const emitConnectedSpy = jest.spyOn(EventProxyService.instance, 'emitConnected');
 
-    // The first 2 requests should be 404 but not emit DISCONNECTED
-    expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
+    // Sub-threshold failures resolve to a real Response object (503), never a
+    // synthesized 404 or a non-Response value, and do not emit DISCONNECTED.
+    let firstFailure = await httpService.httpRequestGET(mockEndpoint);
+    expect(firstFailure).toBeInstanceOf(Response);
+    expect(firstFailure.ok).toBe(false);
+    expect(firstFailure.status).toBe(503);
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     // The OK request should reset the counter
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(true);
@@ -137,11 +141,9 @@ describe('HttpProxyService', () => {
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     expect(emitDisconnectedSpy).not.toHaveBeenCalled();
-    try {
-      await httpService.httpRequestGET(mockEndpoint);
-    }
-    catch (error) {
-      expect(emitDisconnectedSpy).toHaveBeenCalledTimes(1);
-    }
+    // On the 3rd consecutive failure the request rejects with an NRPProxyError
+    // (explicit signalling) and DISCONNECTED is emitted exactly once.
+    await expect(httpService.httpRequestGET(mockEndpoint)).rejects.toBeInstanceOf(NRPProxyError);
+    expect(emitDisconnectedSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/proxy/__tests__/nrp-user-service.test.js
+++ b/src/services/proxy/__tests__/nrp-user-service.test.js
@@ -101,6 +101,26 @@ describe('NrpUserService', () => {
     expect(groups).toBeDefined();
   });
 
+  test('does not cache a failed user groups request and retries', async () => {
+    // start from a clean cache
+    NrpUserService.instance.currentUserGroups = undefined;
+
+    // first call fails: must not cache the failure, degrade to an empty list
+    jest.spyOn(NrpUserService.instance, 'httpRequestGET')
+      .mockImplementationOnce(async () => {
+        throw new Error('Test error');
+      });
+    let groups = await NrpUserService.instance.getCurrentUserGroups();
+    expect(groups).toEqual([]);
+    expect(NrpUserService.instance.currentUserGroups).toBeFalsy();
+
+    // second call (network restored via MSW) fetches again and succeeds
+    groups = await NrpUserService.instance.getCurrentUserGroups();
+    expect(Array.isArray(groups)).toBe(true);
+    expect(groups.length).toBeGreaterThan(0);
+    expect(NrpUserService.instance.currentUserGroups).toBeTruthy();
+  });
+
   test('can determine group membership', async () => {
     expect(await NrpUserService.instance.isGroupMember(MockUserGroups[0].name)).toBe(true);
     expect(await NrpUserService.instance.isGroupMember('not-a-group')).toBe(false);

--- a/src/services/proxy/event-proxy-service.js
+++ b/src/services/proxy/event-proxy-service.js
@@ -7,7 +7,6 @@
  */
 
 import { EventEmitter } from 'events';
-import { NRPProxyError } from './http-proxy-service';
 import DialogService from '../dialog-service';
 
 let _instance = null;
@@ -93,23 +92,23 @@ export default class EventProxyService extends EventEmitter {
 
 
   /**
-   * Throws NRPProxyError exception when connection is lost.
+   * Updates the connection state when the proxy connection is lost.
    *
    * @listens EventProxyService.EVENTS.DISCONNECTED
    *
-   * @param {object} obj is a objest with `code` and `data` fields
-   * which are displayed in the dialog together with the `stack`
+   * @param {object} obj is an object with `code` and `data` fields describing
+   * the failure; it is recorded for diagnostics and consumed by listeners.
    */
   onDisconnected(obj){
     this.connected = false;
     if (!this.initialized) {
       this.initialized = true;
     }
-    throw new NRPProxyError(
-      'Failed to communicate with proxy.',
-      obj.code,//requestURL.href,
-      obj.data//JSON.stringify(options, null, 4)
-    );
+    // Record the last disconnect reason instead of throwing from inside the
+    // listener. Throwing here made the failure surface as an exception
+    // propagating out of EventEmitter.emit(), which was fragile. The failure
+    // is now signalled explicitly by HttpProxyService.performRequest.
+    this.lastError = obj || null;
   }
 
 }

--- a/src/services/proxy/http-proxy-service.js
+++ b/src/services/proxy/http-proxy-service.js
@@ -58,7 +58,7 @@ export class HttpProxyService extends HttpService {
     const requestURL = new URL(path, this.proxyURL);
     try {
       await AuthenticationService.instance.promiseInitialized;
-      let token = AuthenticationService.instance.getToken();
+      let token = await AuthenticationService.instance.getToken();
       options.headers.Authorization = 'Bearer ' + token;
     }
     catch (error) {

--- a/src/services/proxy/http-proxy-service.js
+++ b/src/services/proxy/http-proxy-service.js
@@ -63,7 +63,13 @@ export class HttpProxyService extends HttpService {
     }
     catch (error) {
       console.error(error);
-      return false;
+      // Never return a non-Response value (used to return `false`): callers
+      // expect either a Response or a thrown NRPProxyError.
+      throw new NRPProxyError(
+        'Failed to obtain an authentication token for the proxy request.',
+        requestURL.href,
+        error && error.message
+      );
     }
 
     // add data to the request
@@ -80,15 +86,29 @@ export class HttpProxyService extends HttpService {
     }
     catch (error) {
       this.failedRequestsCount++;
+      const disconnectInfo = {
+        code: requestURL.href,
+        data:
+          'Error occured: \n' + (error && error.message) +
+          '\nwith options:\n' + JSON.stringify(options, null, 4)
+      };
       if (this.failedRequestsCount >= MAX_FAILED_REQUESTS) {
-        EventProxyService.instance.emitDisconnected({
-          code: requestURL.href,
-          data:
-            'Error occured: \n' + error.message + '\nwith options:\n' + JSON.stringify(options, null, 4)
-        });
+        EventProxyService.instance.emitDisconnected(disconnectInfo);
+        // Signal the persistent failure explicitly rather than relying on the
+        // disconnect event listener to throw.
+        throw new NRPProxyError(
+          'Failed to communicate with proxy.',
+          disconnectInfo.code,
+          disconnectInfo.data
+        );
       }
-      // TODO: the Error is thrown (emitDisconnected) before the response is generated ??
-      return new Response(JSON.stringify([]), {status: 404});
+      // Below the failure threshold, return a real Response (Service
+      // Unavailable) so callers uniformly get a Response object with a false
+      // `ok` flag, instead of a synthesized 404 that masks a network error.
+      return new Response(
+        JSON.stringify({ error: 'Proxy request failed', code: requestURL.href }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     // error handling

--- a/src/services/proxy/nrp-user-service.js
+++ b/src/services/proxy/nrp-user-service.js
@@ -88,12 +88,24 @@ class NrpUserService extends HttpProxyService {
   /**
    * Gives you the currently defined user groups.
    *
+   * @param {boolean} force - force a refresh instead of using the cached value
    * @return currentUserGroups - the user groups currently belonging to
    */
-  async getCurrentUserGroups() {
-    if (!this.currentUserGroups) {
-      let response = await this.httpRequestGET(IDENTITY_ME_GROUPS_URL);
-      this.currentUserGroups = response.json();
+  async getCurrentUserGroups(force = false) {
+    if (force || !this.currentUserGroups) {
+      try {
+        let response = await this.httpRequestGET(IDENTITY_ME_GROUPS_URL);
+        // Await the parsed body: the previous code cached the unresolved
+        // promise returned by response.json().
+        this.currentUserGroups = await response.json();
+      }
+      catch (error) {
+        // Do NOT cache a failure — clear it so the next call retries — and
+        // return an empty group list so callers degrade gracefully.
+        this.currentUserGroups = undefined;
+        this.emit(NrpUserService.EVENTS.DISCONNECTED);
+        return [];
+      }
     }
 
     return this.currentUserGroups;

--- a/src/services/roslib-service.js
+++ b/src/services/roslib-service.js
@@ -29,14 +29,25 @@ class RoslibService {
   /**
    * Create a new connection or return an existing one to a ROS websocket.
    * @param {string} url - URL of the ROS websocket to connect to
+   * @returns {Promise<object>} the ROSLIB.Ros connection
    */
-  getConnection(url) {
-    if (!this.connections.has(url)) {
-      let urlWithAuth = url + '?token=' + AuthenticationService.instance.getToken();
-      this.connections.set(url, new ROSLIB.Ros({ url: urlWithAuth }));
+  async getConnection(url) {
+    const token = await AuthenticationService.instance.getToken();
+    const cached = this.connections.get(url);
+    // The cache is keyed by the clean URL, never by the token-bearing URL, so a
+    // refreshed token does not leak a second cached connection. When the token
+    // changes we recreate the connection so the new token reaches the ROS
+    // websocket (which bakes the token into its connection URL and would
+    // otherwise keep reconnecting with a stale/expired token).
+    if (!cached || cached.token !== token) {
+      if (cached && cached.ros && typeof cached.ros.close === 'function') {
+        cached.ros.close();
+      }
+      let urlWithAuth = url + '?token=' + token;
+      this.connections.set(url, { ros: new ROSLIB.Ros({ url: urlWithAuth }), token });
     }
 
-    return this.connections.get(url);
+    return this.connections.get(url).ros;
   };
 
   /**

--- a/src/services/roslib-service.js
+++ b/src/services/roslib-service.js
@@ -74,13 +74,22 @@ class RoslibService {
     return this.createTopic(connection, topicName, 'std_msgs/String');
   };
 
-  createService(connection, serviceName, additionalOptions) {
+  /**
+   * Create a new ROSLIB.Service.
+   * @param {object} connection - the ROSLIB.Ros connection
+   * @param {string} serviceName - name of the service (the ROS service path)
+   * @param {string} serviceType - the ROS service type (e.g. 'std_srvs/Empty')
+   * @param {object} additionalOptions - additional options to extend the service with
+   */
+  createService(connection, serviceName, serviceType, additionalOptions) {
     return new ROSLIB.Service(
       _.extend(
         {
           ros: connection,
           name: serviceName,
-          serviceType: serviceName
+          // Use the real ROS service type. Previously this was set to the
+          // service name, which is not a valid service type and broke calls.
+          serviceType: serviceType
         },
         additionalOptions
       )


### PR DESCRIPTION
Batch of service-layer robustness fixes from the verified audit. Scope is `src/services/**` only; no component code was touched. Public signatures used by component callers are kept stable.

Ticket: https://hbpneurorobotics.atlassian.net/browse/EBR2-108

## Fixes (one atomic commit each)

1. **`experiments/execution/server-resources-service.js`** — `getServerConfig` resolved with the caught error object, so the launch flow treated it as a valid config and launched on garbage. Now rejects (dialog still shown).
2. **`proxy/http-proxy-service.js`** — `performRequest` could return non-Response values (`false` on auth failure, a synthesized `404` on network failure). Now throws `NRPProxyError` when no token can be obtained, returns an honest `503` Response for tolerated transient failures, and throws `NRPProxyError` explicitly once the failure threshold is reached.
3. **`authentication-service.js`** — (a) OIDC `logout()` called a nonexistent `keycloakClient.clearStoredLocalToken()` that threw and aborted logout; now clears our own token and calls `keycloak.logout({redirectUri})`. (b) `getToken()` returned a possibly-stale token via a fire-and-forget refresh; now `async` and awaits `updateToken`. `HttpService`/`HttpProxyService` callers updated to await.
4. **`mqtt-client-service.js`** — (a) connection loss was undetected; now subscribes to `connect`/`reconnect`/`close`/`offline`/`error`/`disconnect`, tracks a connection state, exposes it via `getConnectionState()` + a state-derived `isConnected()`, and emits `CONNECTION_STATE_CHANGED`/`RECONNECTING`/`ERROR` (keeping `CONNECTED`/`DISCONNECTED`) for the UI (EBR2-110). (b) `unsubscribe` never told the broker to stop and leaked empty arrays; now calls the client's `unsubscribe` and deletes the map entry when the last subscriber leaves.
5. **`proxy/event-proxy-service.js`** — disconnect was signalled by throwing an `NRPProxyError` from inside an EventEmitter listener; replaced with an explicit state update (the caller now signals the failure explicitly, see #2).
6. **`experiments/execution/running-simulation-service.js`** — `simulationReady` polled forever after a `creationUniqueID` mismatch (rejected but kept re-scheduling) and had no upper bound; now stops on mismatch and adds a `maxAttempts` timeout bailout. Interval/maxAttempts are overridable for tests; the public two-arg signature is unchanged.
7. **`proxy/nrp-user-service.js`** — `getCurrentUserGroups` had no error handling and cached `response.json()` (an unresolved promise) permanently; now awaits the body, and on error clears the cache and returns `[]` so later calls retry.
8. **`models/models-storage-service.js`** — the cache used a single `this.models` across all types (returned the wrong type) and kept fetching on an invalid `modelType`; now keyed by `template|custom + modelType` and bails on an invalid type.
9. **`roslib-service.js`** — (a) cached ROS connections baked a one-time auth token in and never refreshed it; now keyed by the clean URL with the token tracked per entry, recreating the connection when the token changes (`getConnection` is now `async`). (b) `createService` set `serviceType` to the service name; now takes an explicit `serviceType`.
10. **`experiments/files/import-experiment-service.js`** — `getImportZipResponses` did `await responses.forEach(async …)` (awaits `undefined`), so the confirmation showed blank names; now parses with `Promise.all(map(…))` in order.

## Tests
Added/adjusted unit tests for each fix (e.g. `getServerConfig` rejects; `simulationReady` mismatch + timeout; MQTT `unsubscribe` calls the client and drops the entry; MQTT connection-state tracking; `getToken` awaits refresh; roslib cache-by-clean-URL + token refresh + real service type; models cache-by-type + invalid bail; user-groups failure not cached; import surfaces real names). Focused non-skipped suites were added where the legacy suites are `describe.skip` (they contain pre-existing broken/deferred tests that were left skipped).

## Verification (Docker `node:20`, `src/config.json` from `config.json.sample.local`, not committed)
- `npm install` — honors `.npmrc` `legacy-peer-deps`
- `npm run build` (vite) — succeeds
- `npx jest --ci` — **15 suites passed; 109 passed, 14 skipped, 123 total** (baseline was 98 passed / 14 skipped; +11 new tests, skip count unchanged)
