### PR TITLE
[EBR2-109] Dialogs, notifications & accessibility pass

### DIFF
--- a/src/components/dialog/__tests__/error-dialog.test.js
+++ b/src/components/dialog/__tests__/error-dialog.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+
+import ErrorDialog from '../error-dialog';
+import DialogService from '../../../services/dialog-service';
+
+describe('ErrorDialog', () => {
+  it('shows the first error with its type and message', async () => {
+    render(<ErrorDialog />);
+    act(() => {
+      DialogService.instance.networkError({ message: 'first boom' });
+    });
+
+    expect(await screen.findByText('Network Error')).toBeInTheDocument();
+    expect(screen.getByText('first boom')).toBeInTheDocument();
+  });
+
+  it('queues subsequent errors and shows each in turn instead of dropping them', async () => {
+    render(<ErrorDialog />);
+    act(() => {
+      DialogService.instance.networkError({ message: 'first boom' });
+      DialogService.instance.dataError({ message: 'second boom' });
+    });
+
+    // First error is displayed while the second waits in the queue.
+    expect(await screen.findByText('first boom')).toBeInTheDocument();
+    expect(screen.getByText(/1 more error queued/i)).toBeInTheDocument();
+    expect(screen.queryByText('second boom')).not.toBeInTheDocument();
+
+    // Dismiss the first -> the queued error is revealed, not lost.
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(await screen.findByText('second boom')).toBeInTheDocument();
+    expect(screen.getByText('Data Error')).toBeInTheDocument();
+    expect(screen.queryByText('first boom')).not.toBeInTheDocument();
+
+    // Dismissing the last error closes the dialog entirely.
+    fireEvent.click(screen.getByLabelText('Close'));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows a clean message and a collapsed technical-details toggle', async () => {
+    render(<ErrorDialog />);
+    act(() => {
+      DialogService.instance.unexpectedError({
+        message: 'human readable message',
+        stack: 'Error: internal at foo'
+      });
+    });
+
+    expect(await screen.findByText('human readable message')).toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: /technical details/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/src/components/dialog/__tests__/notification-dialog.test.js
+++ b/src/components/dialog/__tests__/notification-dialog.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent, act, within, waitFor } from '@testing-library/react';
+
+import NotificationDialog from '../notification-dialog';
+import DialogService from '../../../services/dialog-service';
+
+describe('NotificationDialog', () => {
+  it('renders notifications of different types simultaneously', async () => {
+    render(<NotificationDialog />);
+    act(() => {
+      DialogService.instance.nrpNotification({ message: 'info msg' });
+      DialogService.instance.warningNotification({ message: 'warn msg' });
+    });
+
+    expect(await screen.findByText('info msg')).toBeInTheDocument();
+    expect(screen.getByText('warn msg')).toBeInTheDocument();
+  });
+
+  it('closes the toast that was actioned, not the one at the same array index', async () => {
+    render(<NotificationDialog />);
+    act(() => {
+      DialogService.instance.nrpNotification({ message: 'info msg' });     // Information -> index 0
+      DialogService.instance.warningNotification({ message: 'warn msg' }); // Warning     -> index 1
+    });
+
+    const toasts = await screen.findAllByRole('alert');
+    expect(toasts).toHaveLength(2);
+
+    // Close the SECOND toast. The old index-based close removed the first one.
+    fireEvent.click(within(toasts[1]).getByLabelText('Close'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('warn msg')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('info msg')).toBeInTheDocument();
+  });
+
+  it('ignores a duplicate notification of identical type and message', async () => {
+    render(<NotificationDialog />);
+    act(() => {
+      DialogService.instance.nrpNotification({ message: 'same msg' });
+      DialogService.instance.nrpNotification({ message: 'same msg' });
+    });
+
+    expect(await screen.findAllByText('same msg')).toHaveLength(1);
+  });
+});

--- a/src/components/dialog/error-dialog.js
+++ b/src/components/dialog/error-dialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import { Modal, Button, Collapse } from 'react-bootstrap';
+import { VscClose, VscChevronDown, VscChevronUp } from 'react-icons/vsc';
 
 import DialogService from '../../services/dialog-service.js';
 
@@ -9,13 +10,15 @@ class ErrorDialog extends React.Component{
   constructor(props) {
     super(props);
     this.state = {
-      error: undefined,
+      // Queue of incoming errors; the head is displayed and the rest wait
+      // their turn so no error is silently dropped.
+      errors: [],
       isErrorSourceDisplayed: false
     };
+    this.onError = this.onError.bind(this);
   }
 
-  async componentDidMount() {
-    this.onError = this.onError.bind(this);
+  componentDidMount() {
     DialogService.instance.addListener(
       DialogService.EVENTS.ERROR, this.onError
     );
@@ -28,71 +31,106 @@ class ErrorDialog extends React.Component{
   }
 
   onError(error) {
-    // Do not overwrite with the new incoming errors
-    if (!this.state.error) {
-      this.setState({
-        error: error
-      });
-    }
+    // Append every error so subsequent ones are shown in turn instead of
+    // being discarded while one is already on screen.
+    this.setState((prevState) => ({
+      errors: [...prevState.errors, error]
+    }));
   }
 
   handleClose() {
-    this.setState({
-      error: undefined,
+    // Drop the current error and reveal the next queued one (if any).
+    this.setState((prevState) => ({
+      errors: prevState.errors.slice(1),
       isErrorSourceDisplayed: false
-    });
+    }));
   }
 
-  sourceDisplay() {
-    this.setState({
-      isErrorSourceDisplayed: !this.state.isErrorSourceDisplayed
-    });
+  toggleSourceDisplay() {
+    this.setState((prevState) => ({
+      isErrorSourceDisplayed: !prevState.isErrorSourceDisplayed
+    }));
+  }
+
+  hasTechnicalDetails(error) {
+    return Boolean(error.code || error.data || error.stack);
+  }
+
+  formatDetail(value) {
+    if (typeof value === 'string') {
+      return value;
+    }
+    try {
+      return JSON.stringify(value, null, 2);
+    }
+    catch (e) {
+      return String(value);
+    }
   }
 
   render(){
-    let error = this.state.error;
+    const error = this.state.errors[0];
+    if (!error) {
+      return null;
+    }
+
+    const showDetails = this.state.isErrorSourceDisplayed;
+    const queuedCount = this.state.errors.length - 1;
+
     return (
-      <div>
-        {error?
-          <div className="error-dialog-wrapper">
-            <Modal.Dialog>
-              <Modal.Header>
-                <h4>{error.type}</h4>
-              </Modal.Header>
-              <Modal.Body>
-                <pre>{error.message}</pre>
-                {this.state.isErrorSourceDisplayed
-                  ? <div>
-                    {!error.code && !error.data && !error.stack
-                      ? <h6>No scary details</h6>
-                      : null}
-                    {error.code
-                      ? <div><h6>Code</h6><pre>{error.code}</pre></div>
-                      : null}
-                    {error.data
-                      ? <div><h6>Data</h6><pre>{error.data}</pre></div>
-                      : null}
-                    {error.stack
-                      ? <div><h6>Stack Trace</h6><pre>{error.stack}</pre></div>
-                      : null}
-                  </div>
-                  : null
-                }
-              </Modal.Body>
-              <Modal.Footer>
-                <div>
-                  <Button variant="warning" onClick={() => this.handleClose()}>
-                    <span className="glyphicon glyphicon-remove"></span> Close
-                  </Button>
-                  <Button variant="light" onClick={() => this.sourceDisplay()}>
-                    {this.state.isErrorSourceDisplayed ? 'Hide' : 'Show'} scary details <span></span>
-                  </Button>
+      <Modal
+        show
+        onHide={() => this.handleClose()}
+        keyboard
+        backdrop
+        centered
+        aria-labelledby="error-dialog-title"
+        className="error-dialog"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="error-dialog-title" as="h4">{error.type}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="error-dialog-message">{error.message}</p>
+          {this.hasTechnicalDetails(error)
+            ? <div>
+              <Button
+                variant="link"
+                className="error-dialog-details-toggle"
+                onClick={() => this.toggleSourceDisplay()}
+                aria-expanded={showDetails}
+                aria-controls="error-dialog-technical-details"
+              >
+                {showDetails ? <VscChevronUp /> : <VscChevronDown />}
+                {showDetails ? ' Hide technical details' : ' Show technical details'}
+              </Button>
+              <Collapse in={showDetails}>
+                <div id="error-dialog-technical-details">
+                  {error.code
+                    ? <div><h6>Code</h6><pre>{this.formatDetail(error.code)}</pre></div>
+                    : null}
+                  {error.data
+                    ? <div><h6>Data</h6><pre>{this.formatDetail(error.data)}</pre></div>
+                    : null}
+                  {error.stack
+                    ? <div><h6>Stack trace</h6><pre>{this.formatDetail(error.stack)}</pre></div>
+                    : null}
                 </div>
-              </Modal.Footer>
-            </Modal.Dialog>
-          </div>
-          : null}
-      </div>
+              </Collapse>
+            </div>
+            : null}
+        </Modal.Body>
+        <Modal.Footer>
+          {queuedCount > 0
+            ? <span className="error-dialog-queue-count">
+              {queuedCount} more {queuedCount > 1 ? 'errors' : 'error'} queued
+            </span>
+            : null}
+          <Button variant="warning" onClick={() => this.handleClose()}>
+            <VscClose /> Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
     );
   }
 }

--- a/src/components/dialog/notification-dialog.js
+++ b/src/components/dialog/notification-dialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Toast } from 'react-bootstrap';
+import { v4 as uuidv4 } from 'uuid';
 
 import DialogService from '../../services/dialog-service.js';
 
@@ -13,10 +14,10 @@ class NotificationDialog extends React.Component{
     };
     this.infoDelayMS = 6000;
     this.warnDelayMS = 15000;
+    this.onNotification = this.onNotification.bind(this);
   }
 
-  async componentDidMount() {
-    this.onNotification = this.onNotification.bind(this);
+  componentDidMount() {
     DialogService.instance.addListener(
       DialogService.EVENTS.NOTIFICATION, this.onNotification
     );
@@ -29,50 +30,44 @@ class NotificationDialog extends React.Component{
   }
 
   onNotification(notification) {
-    // avoid duplicates
-    var isType = false;
-    var isMsg = false;
-    var index = 0;
-    this.state.notifications.forEach((notif) =>{
-      if (notification.type===notif.type) {
-        if (notification.message===notif.message){
-          isMsg = true;
-        }
-        else {
-          index = this.state.notifications.indexOf(notif);
-          isType = true;
-        }
+    this.setState((prevState) => {
+      // Ignore an identical notification (same type and message) that is
+      // already visible.
+      const isDuplicate = prevState.notifications.some(
+        (notif) => notif.type === notification.type && notif.message === notification.message
+      );
+      if (isDuplicate) {
+        return null;
       }
-    });
-    if (isType){
-      this.handleClose(index);
-    }
-    if (!isMsg){
-      this.setState({
-        notifications: [...this.state.notifications, notification]
-      });
-    }
-  }
-
-  handleClose(index) {
-    var copy = [...this.state.notifications];
-    copy.splice(index, 1);
-    this.setState({
-      notifications: copy
+      // Replace any earlier notification of the same type, then append the new
+      // one carrying a stable id so it can later be dismissed unambiguously.
+      const remaining = prevState.notifications.filter(
+        (notif) => notif.type !== notification.type
+      );
+      return {
+        notifications: [...remaining, { ...notification, id: uuidv4() }]
+      };
     });
   }
 
-  // TODO: [NRRPLT-8774] the Toast doesn't disappear if there are more than one notification
+  handleClose(id) {
+    // Dismiss by stable id rather than array index so the correct toast is
+    // removed even when several are visible or one auto-hides.
+    this.setState((prevState) => ({
+      notifications: prevState.notifications.filter((notif) => notif.id !== id)
+    }));
+  }
+
   render(){
     let notifications = this.state.notifications;
     return(
       <div className='toast-notification-wrapper'>
         {notifications.length!==0?
           <ol>
-            {notifications.map((notification, index) => {
+            {notifications.map((notification) => {
               return (
-                <li key={index} className='no-style'>
-                  <Toast className='toast-width' onClose={(index) => this.handleClose(index)}
+                <li key={notification.id} className='no-style'>
+                  <Toast className='toast-width' onClose={() => this.handleClose(notification.id)}
                     delay={notification.type === 'Warning' ? this.warnDelayMS : this.infoDelayMS}
                     animation={true} autohide={true}>
                     <Toast.Header className={notification.type === 'Warning' ? 'warning' : 'info'} >

--- a/src/components/experiment-list/experiment-list-element.js
+++ b/src/components/experiment-list/experiment-list-element.js
@@ -70,6 +70,19 @@ class ExperimentListElement extends React.Component {
     this.props.navigate('/experiment/' + expID);
   }
 
+  handleRowKeyDown = (event) => {
+    // Keyboard equivalent of clicking the row. Only act when the row itself is
+    // focused (not a nested button/input), so inner controls keep their own
+    // Enter/Space behaviour. Space is prevented to avoid page scrolling.
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.setState({ selected: true });
+    }
+  }
+
   getAvailabilityInfo() {
     let status;
     if (this.props.availableServers && this.props.availableServers.length > CLUSTER_THRESHOLDS.AVAILABLE) {
@@ -135,7 +148,11 @@ class ExperimentListElement extends React.Component {
     return (
       <div className='list-entry-wrapper flex-container left-right'
         style={{ position: 'relative' }}
+        role='button'
+        tabIndex={0}
+        aria-expanded={!!this.state.selected}
         onClick={() => this.setState({ selected: true })}
+        onKeyDown={this.handleRowKeyDown}
         ref={this.wrapperRef}>
 
         {/* This is the remove dialog */}
@@ -173,29 +190,32 @@ class ExperimentListElement extends React.Component {
               null
             }
             { this.state.nameEditingVisible && !this.state.templateTab ?
-              <button className='list-entry-edit-buttons' onClick={() => {
-                this.setState({ nameEditingVisible: false });
-                this.setState({ visibleName: this.state.edibleName});
-                ExperimentStorageService.instance.renameExperiment(exp.id, this.state.edibleName);
-              }}>
+              <button type='button' aria-label='Save experiment name'
+                className='list-entry-edit-buttons' onClick={() => {
+                  this.setState({ nameEditingVisible: false });
+                  this.setState({ visibleName: this.state.edibleName});
+                  ExperimentStorageService.instance.renameExperiment(exp.id, this.state.edibleName);
+                }}>
                 <VscCheck/>
               </button>
               :
               null
             }
             { this.state.nameEditingVisible && !this.state.templateTab ?
-              <button className='list-entry-edit-buttons' onClick={() => {
-                this.setState({ nameEditingVisible: false });
-                this.setState({ edibleName: this.state.visibleName});
-              }}>
+              <button type='button' aria-label='Discard name changes'
+                className='list-entry-edit-buttons' onClick={() => {
+                  this.setState({ nameEditingVisible: false });
+                  this.setState({ edibleName: this.state.visibleName});
+                }}>
                 <VscDiscard/>
               </button>
               :
               null
             }
             { !this.state.nameEditingVisible && !this.state.templateTab ?
-              <button className='list-entry-edit-buttons' onClick={() => this.setState(
-                { nameEditingVisible: true })}>
+              <button type='button' aria-label='Rename experiment'
+                className='list-entry-edit-buttons' onClick={() => this.setState(
+                  { nameEditingVisible: true })}>
                 <VscEdit/>
               </button>
               :
@@ -370,7 +390,7 @@ class ExperimentListElement extends React.Component {
             <SimulationDetails simulations={exp.joinableServers} />
             : null
           }
-          {exp.rights.launch ?
+          {exp.rights.launch && config.cloneDate ?
             <div className='experiment-clone-date'>
               Cloning date: {config.cloneDate}
             </div>

--- a/src/components/nrp-header/nrp-header.js
+++ b/src/components/nrp-header/nrp-header.js
@@ -70,10 +70,17 @@ export default class NrpHeader extends React.Component {
             <Link to='/' className='header-link'>HOME</Link>
           </div>
           <div>
-            <Link to='/experiments-overview'
-              className={this.state.proxyConnected ? 'header-link' : 'header-link-disabled'}>
-              EXPERIMENTS
-            </Link>
+            {this.state.proxyConnected ?
+              <Link to='/experiments-overview' className='header-link'>
+                EXPERIMENTS
+              </Link>
+              :
+              // Disabled while the proxy is offline: render an inert span (no
+              // route, out of tab order, not activatable) that keeps the look.
+              <span className='header-link-disabled' aria-disabled='true' tabIndex={-1}>
+                EXPERIMENTS
+              </span>
+            }
           </div>
           <a
             href='https://neurorobotics.net/'


### PR DESCRIPTION
Implements **[EBR2-109](https://hbpneurorobotics.atlassian.net/browse/EBR2-109)** — dialogs, notifications & accessibility pass. Modern stack APIs (React 18 · react-router v6 · MUI v5 · Bootstrap 5 / react-bootstrap 2, Node 20). Scope limited to `src/components/dialog/**`, `experiment-list/experiment-list-element.js`, `nrp-header/nrp-header.js` (services untouched to stay conflict-free with EBR2-108).

## Fixes

### 1. `dialog/error-dialog.js`
- Replaced the bare `Modal.Dialog` (no focus trap, no Escape, no backdrop, no dialog role) with react-bootstrap 2 `<Modal show onHide keyboard backdrop centered aria-labelledby>`, which gives a focus trap, Escape/backdrop dismiss and `role="dialog"`/`aria-modal`.
- **Errors are now queued** (state array, `slice(1)` on close) so every error is shown in turn instead of only the first — subsequent errors are no longer dropped. A "N more errors queued" hint is shown while the queue is non-empty.
- Dropped the broken Bootstrap 3 `glyphicon` for `react-icons` (`VscClose`/`VscChevron*`, the icon family already used in this tree).
- Shows a clean human message; code/data/stack moved into a `<Collapse>`-based **technical-details** region behind an `aria-expanded`/`aria-controls` toggle (no more raw stack dump). Non-string details are safely stringified.

### 2. `dialog/notification-dialog.js`
- The `Toast` `onClose` closure shadowed the `.map` index, so closing/auto-hiding removed the **wrong** toast. Each notification now carries a **stable uuid**; close and auto-dismiss act by id (also used as the React key). Removed the stale `NRRPLT-8774` TODO that this fixes.

### 3. `experiment-list/experiment-list-element.js`
- Row is now keyboard-operable: `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Space) that mirrors the mouse-click expand; the handler ignores events bubbling from nested controls, and `aria-expanded` reflects state. Mouse behaviour is unchanged.
- Icon-only edit / confirm / discard buttons got `aria-label`s and `type="button"`.
- "Cloning date" line only renders when `config.cloneDate` is actually present.

### 4. `nrp-header/nrp-header.js`
- The "disabled" EXPERIMENTS nav link was still focusable/navigable. When the proxy is offline it now renders an inert `<span>` (no route, no `onClick`, `aria-disabled`, `tabIndex={-1}`) that keeps the disabled look but cannot be activated by pointer or keyboard.

## Tests
Added RTL coverage for the two dialog fixes (`src/components/dialog/__tests__/`): the error queue + details toggle, and id-based toast dismissal (asserts the actioned toast is removed, not the one at the same index). The experiment-list/header components pull in heavier service singletons, so those are covered by build + manual reasoning per the mostly service-only suite.

## Verification (Docker `node:20`, repo mounted, `cp src/config.json.sample.local src/config.json`)
- `npm install` (honors `.npmrc` legacy-peer-deps) — exit 0
- `npm run build` (vite) — exit 0, built in ~7s
- `npx jest --ci` — exit 0: **Test Suites: 3 skipped, 14 passed, 17 total; Tests: 14 skipped, 104 passed, 118 total** (baseline ~98 passed + 14 skipped; +6 from the new dialog tests)
- `eslint` clean on all changed files