### PR TITLE
[EBR2-110] Workbench, xpra, TF-editor & shell UX feedback

### DIFF
--- a/src/components/entry-page/entry-page.css
+++ b/src/components/entry-page/entry-page.css
@@ -1,11 +1,25 @@
 .entry-page-wrapper {
-  height: 100vh;
+  /* Grow with content instead of clipping it to exactly one viewport. */
+  min-height: 100vh;
   display: grid;
   grid-template-rows: 200px auto;
   grid-template-columns: 25% auto 25%;
   grid-template-areas:
     "nrp-header nrp-header nrp-header"
     "dashboard experiments news";
+}
+
+/* Collapse the 3-column landing to a single column on narrow screens. */
+@media (max-width: 900px) {
+  .entry-page-wrapper {
+    grid-template-rows: auto;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "nrp-header"
+      "dashboard"
+      "experiments"
+      "news";
+  }
 }
 
 .entry-page-header {
@@ -39,7 +53,51 @@
   text-align: left;
   padding: 20px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+}
+
+.news-frame-container {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 300px;
+}
+
+.news-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.news-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
+  font-style: italic;
+}
+
+.news-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  color: #555;
+}
+
+.news-fallback-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.news-retry {
+  padding: 4px 12px;
+  cursor: pointer;
 }
 
 .sidebar-left {

--- a/src/components/entry-page/entry-page.js
+++ b/src/components/entry-page/entry-page.js
@@ -22,7 +22,12 @@ export default class EntryPage extends React.Component {
 
     this.state = {
       experimentIDs: [],
-      experimentInfos: []
+      experimentInfos: [],
+      // The news iframe is a cross-origin embed that can hang or fail; track
+      // its load so we can show a loading state and an error/empty fallback.
+      newsLoading: true,
+      newsError: false,
+      newsKey: 0
     };
   }
 
@@ -32,6 +37,7 @@ export default class EntryPage extends React.Component {
       ExperimentStorageService.EVENTS.UPDATE_EXPERIMENTS,
       this.onUpdateStorageExperiments
     );
+    this.startNewsLoadTimeout();
   }
 
   componentWillUnmount() {
@@ -41,7 +47,45 @@ export default class EntryPage extends React.Component {
       ExperimentStorageService.EVENTS.UPDATE_EXPERIMENTS,
       this.onUpdateStorageExperiments
     );
+    this.clearNewsLoadTimeout();
   }
+
+  /**
+   * A cross-origin iframe that never loads fires no `onError`, so use a
+   * timeout watchdog to fall back to the error state.
+   */
+  startNewsLoadTimeout() {
+    this.clearNewsLoadTimeout();
+    this.newsLoadTimeout = setTimeout(() => {
+      if (this.state.newsLoading) {
+        this.setState({ newsLoading: false, newsError: true });
+      }
+    }, EntryPage.NEWS_LOAD_TIMEOUT_MS);
+  }
+
+  clearNewsLoadTimeout() {
+    if (this.newsLoadTimeout) {
+      clearTimeout(this.newsLoadTimeout);
+      this.newsLoadTimeout = undefined;
+    }
+  }
+
+  onNewsLoad = () => {
+    this.clearNewsLoadTimeout();
+    this.setState({ newsLoading: false, newsError: false });
+  };
+
+  onNewsError = () => {
+    this.clearNewsLoadTimeout();
+    this.setState({ newsLoading: false, newsError: true });
+  };
+
+  retryNews = () => {
+    this.setState(
+      (state) => ({ newsLoading: true, newsError: false, newsKey: state.newsKey + 1 }),
+      () => this.startNewsLoadTimeout()
+    );
+  };
 
   onUpdateStorageExperiments(storageExperiments) {
     this.getLastExperiments(storageExperiments);
@@ -96,8 +140,35 @@ export default class EntryPage extends React.Component {
             </Link>
           }
         </div>
-        <iframe title='nrp-news' className='news' src='https://neurorobotics.net/latest.html' />
+        <div className='news'>
+          <div className='news-frame-container'>
+            {this.state.newsError ?
+              <div className='news-fallback'>
+                <div>Latest news could not be loaded.</div>
+                <div className='news-fallback-actions'>
+                  <button className='news-retry' onClick={this.retryNews}>Retry</button>
+                  <a href='https://neurorobotics.net/latest.html' target='_blank' rel='noreferrer'>
+                    Open neurorobotics.net
+                  </a>
+                </div>
+              </div>
+              :
+              <React.Fragment>
+                {this.state.newsLoading &&
+                  <div className='news-loading'>Loading latest news…</div>
+                }
+                <iframe key={this.state.newsKey} title='nrp-news' className='news-frame'
+                  src='https://neurorobotics.net/latest.html'
+                  onLoad={this.onNewsLoad}
+                  onError={this.onNewsError} />
+              </React.Fragment>
+            }
+          </div>
+        </div>
       </div>
     );
   }
 }
+
+// How long to wait for the news iframe to load before showing the fallback.
+EntryPage.NEWS_LOAD_TIMEOUT_MS = 12000;

--- a/src/components/experiment-files-viewer/experiment-files-viewer.js
+++ b/src/components/experiment-files-viewer/experiment-files-viewer.js
@@ -157,18 +157,18 @@ export default class ExperimentFilesViewer extends React.Component {
                 {this.props.experiments.map(experiment => {
                   let experimentServerFiles = RemoteExperimentFilesService.instance
                     .mapServerFiles.get(experiment.uuid);
-                  let experimentLocalFiles = RemoteExperimentFilesService.instance.mapLocalFiles.get(experiment.uuid);
 
                   return (
                     <li key={experiment.id || experiment.configuration.id}
                       className={this.getExperimentsListItemClass(experiment)}
                       onClick={() => {
-                        if (experimentLocalFiles) {
-                          this.setState({
-                            selectedExperiment: experiment,
-                            selectedFilepaths: undefined
-                          });
-                        }
+                        // Always select the experiment: if it has no local
+                        // files the file panel now shows an explicit empty
+                        // state instead of the click being a silent no-op.
+                        this.setState({
+                          selectedExperiment: experiment,
+                          selectedFilepaths: undefined
+                        });
                       }}>
                       {experiment.configuration.SimulationName}
                       <div className='experiment-li-buttons'>
@@ -243,7 +243,12 @@ export default class ExperimentFilesViewer extends React.Component {
                   >
                     {this.renderFileTree(selectedExperimentFiles)}
                   </TreeView>
-                  : <span style={{margin: '20px'}}>Please select an experiment on the left first.</span>
+                  : this.state.selectedExperiment
+                    ? <span style={{margin: '20px'}}>
+                      No local files found for this experiment yet. Pick a local working directory
+                      and download the experiment to see its files here.
+                    </span>
+                    : <span style={{margin: '20px'}}>Please select an experiment on the left first.</span>
                 }
               </div>
             </div>

--- a/src/components/experiment-list/import-experiment-buttons.css
+++ b/src/components/experiment-list/import-experiment-buttons.css
@@ -16,3 +16,14 @@
     cursor: pointer;
     height: 50%;
 }
+
+.import-progress {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 12px;
+}
+
+.import-progress-text {
+    font-style: italic;
+}

--- a/src/components/experiment-list/import-experiment-buttons.js
+++ b/src/components/experiment-list/import-experiment-buttons.js
@@ -11,11 +11,13 @@ import frontendConfig from '../../config.json';
 
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
+import Spinner from 'react-bootstrap/Spinner';
 export default class ImportExperimentButtons extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      importKey: 0
+      importKey: 0,
+      isImporting: false
     };
     // By default, we enable the scan storage button, even if it's not in the config.
     // For the online version, we explicitly disable it.
@@ -160,11 +162,11 @@ export default class ImportExperimentButtons extends React.Component {
 
         {/* Import buttons */}
         <div className='list-entry-buttons flex-container center'>
-          <input disabled={false} id='folder' type='file' style={{ display: 'none' }}
+          <input disabled={this.state.isImporting} id='folder' type='file' style={{ display: 'none' }}
             multiple directory='' webkitdirectory=''
             onChange={(event) => this.importExperimentFolderChange(event)}
             key={this.state.importKey + 1} />
-          <input disabled={false} id='zip' type='file' style={{ display: 'none' }}
+          <input disabled={this.state.isImporting} id='zip' type='file' style={{ display: 'none' }}
             multiple accept='.zip'
             onChange={(event) => this.importZippedExperimentChange(event)}
             key={this.state.importKey} />
@@ -177,7 +179,7 @@ export default class ImportExperimentButtons extends React.Component {
                 </Tooltip>
               }
             >
-              <button type='button' className='btn btn-outline-dark'>
+              <button type='button' className='btn btn-outline-dark' disabled={this.state.isImporting}>
                 <label htmlFor='folder' className='import-button'>
                   <FaFolder /> Import folder
                 </label>
@@ -191,7 +193,7 @@ export default class ImportExperimentButtons extends React.Component {
                 </Tooltip>
               }
             >
-              <button type='button' className='btn btn-outline-dark'
+              <button type='button' className='btn btn-outline-dark' disabled={this.state.isImporting}
                 data-bs-toggle='tooltip' data-bs-placement='bottom'
               >
                 <label htmlFor='zip' className='import-button'><FaFileArchive /> Import zip</label>
@@ -200,12 +202,19 @@ export default class ImportExperimentButtons extends React.Component {
 
             {
               this.scanStorage ?
-                <button type='button' className='btn btn-outline-dark' onClick={() => this.scanStorageClick()}>
+                <button type='button' className='btn btn-outline-dark' disabled={this.state.isImporting}
+                  onClick={() => this.scanStorageClick()}>
                   <FaAudible /> Scan Storage
                 </button> :
                 null
             }
           </div>
+          {this.state.isImporting &&
+            <span className='import-progress'>
+              <Spinner animation='border' size='sm' role='status' />
+              <span className='import-progress-text'>Importing…</span>
+            </span>
+          }
         </div>
       </div>
     );

--- a/src/components/experiment-workbench/experiment-workbench.css
+++ b/src/components/experiment-workbench/experiment-workbench.css
@@ -1,77 +1,12 @@
-.simulation-view-wrapper {
-  display: grid;
-  grid-template-rows: auto auto;
-  grid-template-columns: 68px auto;
-  grid-template-areas: 
-      "simulation-view-header simulation-view-header"
-      "simulation-view-sidebar simulation-view-mainview";
-}
-
-.simulation-view-header {
-  grid-area: simulation-view-header;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  background-color: yellow;
-  padding: 3px;
-}
-
-.simulation-view-sidebar {
-  padding: 2px;
-  grid-area: simulation-view-sidebar;
-  background-color: green;
-}
-
-.simulation-view-mainview {
-  grid-area: simulation-view-mainview;
-  background-color: red;
-}
-
 .flexlayout__layout {
   position: relative;
   height: calc(100vh - 63px);
 }
 
+/* Only scroll when the tab content actually overflows, instead of forcing
+   scrollbars on every tab. */
 .flexlayout__tab {
-  overflow: scroll;
-}
-
-.simulation-view-controls {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.simulation-view-control-buttons {
-  padding: 0px 10px 0px 10px;
-}
-
-.simulation-view-time-info {
-  display: grid;
-  gap: 3px;
-  grid-template-rows: repeat(3, 1fr);
-  grid-template-columns: repeat(2, 1fr);
-
-  padding: 0px 10px 0px 10px;
-
-  font-size: 0.7em;
-}
-
-.simulation-view-experiment-title {
-  padding: 0px 10px 0px 10px;
-  font-weight: bold;
-}
-
-.simulation-tool-button {
-  width: 60px;
-  height: 60px;
-  margin: 2px;
-  padding: 2px;
-  font-size: 0.7em;
-  color: black;
-  font-weight: bold;
-  background-color: lightgray;
+  overflow: auto;
 }
 
 .simulation-status-error {

--- a/src/components/experiment-workbench/experiment-workbench.css
+++ b/src/components/experiment-workbench/experiment-workbench.css
@@ -33,6 +33,29 @@
   background-color: #e6e6e6 !important;
 }
 
+/* Broker connection-loss banner: makes it obvious the dashboard is no
+   longer live when the MQTT connection drops. */
+.mqtt-connection-banner {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  margin: 0 8px 4px 8px;
+  font-weight: bold;
+  border-radius: 4px;
+}
+
+.mqtt-connection-banner-reconnecting {
+  color: #6d4c00;
+  background-color: #fff3cd;
+  border: 1px solid #ffe69c;
+}
+
+.mqtt-connection-banner-offline {
+  color: #842029;
+  background-color: #f8d7da;
+  border: 1px solid #f1aeb5;
+}
+
 iframe {
   width: 100%;
   height: 100%;

--- a/src/components/experiment-workbench/experiment-workbench.css
+++ b/src/components/experiment-workbench/experiment-workbench.css
@@ -25,6 +25,14 @@
   background-color: #f8ffc8 !important;
 }
 
+.simulation-status-completed {
+  background-color: #d6f0e0 !important;
+}
+
+.simulation-status-stopped {
+  background-color: #e6e6e6 !important;
+}
+
 iframe {
   width: 100%;
   height: 100%;

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -47,6 +47,18 @@ import CircularProgress from '@mui/material/CircularProgress';
 import packageInfo from '../../../package.json';
 const { version } = packageInfo;
 
+// Human-readable labels for each simulation lifecycle state, so the toolbar
+// shows a clear status instead of the raw backend token.
+const SIMULATION_STATE_LABELS = {
+  [EXPERIMENT_STATE.CREATED]: 'Created',
+  [EXPERIMENT_STATE.STARTED]: 'Running',
+  [EXPERIMENT_STATE.PAUSED]: 'Paused',
+  [EXPERIMENT_STATE.COMPLETED]: 'Completed',
+  [EXPERIMENT_STATE.FAILED]: 'Failed',
+  [EXPERIMENT_STATE.STOPPED]: 'Stopped',
+  [EXPERIMENT_STATE.UNDEFINED]: 'Not started'
+};
+
 const jsonBaseLayout = {
   global: {},
   borders: [],
@@ -340,11 +352,17 @@ class ExperimentWorkbench extends React.Component {
     }
     // if there is no simulation bound
     if (this.state.runningSimulationID === undefined) {
-      this.setState({ simulationState: undefined });
+      // Give immediate feedback for the (potentially long) launch: keep the
+      // toolbar disabled and show the launching spinner until the simulation
+      // reports its first status over MQTT.
+      this.setState({ simulationState: undefined, simStateLoading: true });
       await ExperimentExecutionService.instance.startNewExperiment(
         ExperimentWorkbenchService.instance.experimentInfo
       ).then(async (simResponse) => {
         if (typeof simResponse === 'undefined') {
+          // Nothing was launched: stop the spinner and reflect the failure
+          // instead of leaving the toolbar spinning forever.
+          this.setState({ simStateLoading: false, simulationState: EXPERIMENT_STATE.FAILED });
           console.error('startNewExperiment() returned with simResponse === undefined');
           return;
         }
@@ -357,8 +375,7 @@ class ExperimentWorkbench extends React.Component {
             MQTTPrefix: simInfo.MQTTPrefix
           };
           this.setState({ runningSimulationID: simInfo.simulationID });
-          // get the simulationState from MQTT only
-          this.setState({ simStateLoading: true });
+          // Keep simStateLoading true: the real state now comes from MQTT.
         }
         else {
           throw new Error('Could not parse the response from the backend after initializing the simulation');
@@ -366,6 +383,8 @@ class ExperimentWorkbench extends React.Component {
         ExperimentWorkbenchService.instance.serverURL = simResponse['serverURL'];
         this.serverURL = simResponse['serverURL'];
       }).catch((failure) => {
+        // A failed launch must clear the spinner and surface the error.
+        this.setState({ simStateLoading: false, simulationState: EXPERIMENT_STATE.FAILED });
         DialogService.instance.simulationError({ message: failure });
       });
     }
@@ -454,11 +473,31 @@ class ExperimentWorkbench extends React.Component {
       return 'simulation-status-started';
     case EXPERIMENT_STATE.PAUSED:
       return 'simulation-status-paused';
+    case EXPERIMENT_STATE.COMPLETED:
+      return 'simulation-status-completed';
     case EXPERIMENT_STATE.FAILED:
       return 'simulation-status-error';
+    case EXPERIMENT_STATE.CREATED:
+    case EXPERIMENT_STATE.STOPPED:
+      return 'simulation-status-stopped';
     default:
       return 'simulation-status-default';
     }
+  }
+
+  /**
+   * Human-readable label for the current simulation lifecycle state.
+   * @returns {string} the label to display next to "Simulation State".
+   */
+  getStatusLabel() {
+    const state = this.state.simulationState;
+    if (this.state.simStateLoading && (state === undefined || state === EXPERIMENT_STATE.UNDEFINED)) {
+      return 'Launching…';
+    }
+    if (state === undefined) {
+      return 'Not started';
+    }
+    return SIMULATION_STATE_LABELS[state] || state;
   }
 
   render() {
@@ -616,10 +655,9 @@ class ExperimentWorkbench extends React.Component {
                 <ExperimentTimeBox value='experiment'/>
                 <ExperimentTimeBox value='remaining'/>
                 <Typography align='left' variant='subtitle1' color='inherit' noWrap className={classes.title}>
-                  Simulation State: {
-                    this.state.simStateLoading ?
-                      <CircularProgress size='1rem'/> :
-                      this.state.simulationState
+                  Simulation State: {this.getStatusLabel()}
+                  {this.state.simStateLoading &&
+                    <CircularProgress size='1rem' style={{ marginLeft: 8, verticalAlign: 'middle' }} />
                   }
                 </Typography>
               </Paper>

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -11,6 +11,7 @@ import ExperimentTimeBox from './experiment-time-box';
 import SimulationService from '../../services/experiments/execution/running-simulation-service';
 import ExperimentExecutionService from '../../services/experiments/execution/experiment-execution-service';
 import ServerResourcesService from '../../services/experiments/execution/server-resources-service.js';
+import MqttClientService from '../../services/mqtt-client-service';
 import DialogService from '../../services/dialog-service';
 import { EXPERIMENT_STATE, EXPERIMENT_FINAL_STATE } from '../../services/experiments/experiment-constants';
 import LeaveWorkbenchDialog from './leave-workbench-dialog';
@@ -207,7 +208,8 @@ class ExperimentWorkbench extends React.Component {
       runningSimulationID: undefined,
       simulationState: EXPERIMENT_STATE.UNDEFINED,
       simStateLoading: false,
-      availableServers: []
+      availableServers: [],
+      mqttConnectionState: MqttClientService.instance.getConnectionState()
     };
 
     this.flexlayoutReference = React.createRef();
@@ -249,6 +251,14 @@ class ExperimentWorkbench extends React.Component {
     ServerResourcesService.instance.addListener(
       ServerResourcesService.EVENTS.UPDATE_SERVER_AVAILABILITY,
       this.onUpdateServerAvailability
+    );
+
+    // Track the MQTT connection so the dashboard visibly stops looking "live"
+    // when the broker drops (EBR2-108 connection-state API).
+    this.setState({ mqttConnectionState: MqttClientService.instance.getConnectionState() });
+    MqttClientService.instance.addListener(
+      MqttClientService.EVENTS.CONNECTION_STATE_CHANGED,
+      this.onMqttConnectionStateChanged
     );
   }
 
@@ -293,6 +303,10 @@ class ExperimentWorkbench extends React.Component {
       ServerResourcesService.EVENTS.UPDATE_SERVER_AVAILABILITY,
       this.onUpdateServerAvailability
     );
+    MqttClientService.instance.removeListener(
+      MqttClientService.EVENTS.CONNECTION_STATE_CHANGED,
+      this.onMqttConnectionStateChanged
+    );
     // Remove the simulation when we leave the workbench
     ExperimentWorkbenchService.instance.simulationInfo = undefined;
   }
@@ -305,6 +319,35 @@ class ExperimentWorkbench extends React.Component {
   onUpdateServerAvailability = (availableServers) => {
     this.setState({ availableServers: availableServers });
   };
+
+  /**
+   * Reflects the current MQTT broker connection state in the UI.
+   * @listens MqttClientService.EVENTS.CONNECTION_STATE_CHANGED
+   * @param {string} state one of MqttClientService.CONNECTION_STATES
+   */
+  onMqttConnectionStateChanged = (state) => {
+    this.setState({ mqttConnectionState: state });
+  };
+
+  /**
+   * @returns {string|undefined} a user-facing message when the broker is not
+   * connected (and the dashboard is therefore not live), undefined otherwise.
+   */
+  getMqttConnectionBanner() {
+    const STATES = MqttClientService.CONNECTION_STATES;
+    switch (this.state.mqttConnectionState) {
+    case STATES.CONNECTED:
+      return undefined;
+    case STATES.RECONNECTING:
+      return 'Connection to the simulation broker lost — reconnecting…';
+    case STATES.OFFLINE:
+      return 'The simulation broker is offline — the dashboard is not live.';
+    case STATES.ERROR:
+      return 'Connection error with the simulation broker — the dashboard is not live.';
+    default:
+      return 'Disconnected from the simulation broker — the dashboard is not live.';
+    }
+  }
 
   /**
    * Sets the new simulation status to the component state
@@ -647,6 +690,18 @@ class ExperimentWorkbench extends React.Component {
         {/* This is the content of the main window */}
         <main className={classes.content}>
           <div className={classes.appBarSpacer} />
+          {this.getMqttConnectionBanner() &&
+            <div className={clsx('mqtt-connection-banner',
+              this.state.mqttConnectionState === MqttClientService.CONNECTION_STATES.RECONNECTING
+                ? 'mqtt-connection-banner-reconnecting'
+                : 'mqtt-connection-banner-offline')}
+            role='alert'>
+              {this.state.mqttConnectionState === MqttClientService.CONNECTION_STATES.RECONNECTING &&
+                <CircularProgress size='1rem' color='inherit' style={{ marginRight: 8, verticalAlign: 'middle' }} />
+              }
+              {this.getMqttConnectionBanner()}
+            </div>
+          }
           <Grid container spacing={1} className={classes.container}>
             {/* Chart */}
             <Grid item xs={12}>

--- a/src/components/experiments-overview/experiments-overview.css
+++ b/src/components/experiments-overview/experiments-overview.css
@@ -15,3 +15,9 @@
 .tabs-view {
     grid-area: tabs-view;
 }
+
+.tab-coming-soon {
+    font-size: 0.75em;
+    font-style: italic;
+    opacity: 0.7;
+}

--- a/src/components/experiments-overview/experiments-overview.js
+++ b/src/components/experiments-overview/experiments-overview.js
@@ -154,8 +154,14 @@ export default class ExperimentsOverview extends React.Component {
           onSelect={(index, lastIndex) => this.onSelectTab(index, lastIndex)} >
           <TabList>
             <Tab>My Experiments</Tab>
-            <Tab disabled={true}>New Experiment</Tab>
-            <Tab disabled={true}>Model Libraries</Tab>
+            {/* Not yet available: mark clearly as "coming soon" so the greyed
+                tabs do not read as broken. */}
+            <Tab disabled={true} title='Coming soon'>
+              New Experiment <span className='tab-coming-soon'>(coming soon)</span>
+            </Tab>
+            <Tab disabled={true} title='Coming soon'>
+              Model Libraries <span className='tab-coming-soon'>(coming soon)</span>
+            </Tab>
             <Tab>Experiment Files</Tab>
             <Tab>Templates</Tab>
             <Tab>Running Simulations</Tab>

--- a/src/components/tf-editor/tf-editor.css
+++ b/src/components/tf-editor/tf-editor.css
@@ -40,7 +40,20 @@
 }
 
 .tf-editor-codemirror-container {
-  overflow: scroll;
+  position: relative;
+  overflow: auto;
+}
+
+.tf-editor-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 8px 12px;
+  background-color: #f5f5f5;
+  color: #555;
+  font-style: italic;
+  z-index: 2;
 }
 
 .tf-editor-unsaved-dialog-wrapper {

--- a/src/components/tf-editor/tf-editor.js
+++ b/src/components/tf-editor/tf-editor.js
@@ -8,6 +8,7 @@ import { Modal, Button } from 'react-bootstrap';
 
 import ExperimentStorageService from '../../services/experiments/files/experiment-storage-service';
 import ExperimentWorkbenchService from '../experiment-workbench/experiment-workbench-service';
+import DialogService from '../../services/dialog-service';
 
 import './tf-editor.css';
 
@@ -27,20 +28,38 @@ export default class TransceiverFunctionEditor extends React.Component {
       code: '',
       textChanges: '',
       showDialogUnsavedChanges: false,
-      codeMirrorMarkup: []
+      codeMirrorMarkup: [],
+      isLoading: false,
+      isLoadingContent: false,
+      isSaving: false
     };
   }
 
   async componentDidMount() {
-
-    const workbench = await ExperimentWorkbenchService.instance;
+    const workbench = ExperimentWorkbenchService.instance;
     this.experimentID = workbench.experimentID;
 
-    this.setState({ experimentName: this.experimentID });
-    await this.loadExperimentFiles();
-    const defaultFile = this.files.find(f => f.name === 'simulation_config.json');
-    this.setState({ selectedFile: defaultFile ? defaultFile : this.files.at(0) });
-    await this.loadFileContent(this.state.selectedFile);
+    this.setState({ experimentName: this.experimentID, isLoading: true });
+    try {
+      await this.loadExperimentFiles();
+      // Use a local so the content load does not rely on the (async) setState
+      // above having flushed, and guard against an experiment with no files.
+      const defaultFile = this.files.find(f => f.name === 'simulation_config.json') || this.files.at(0);
+      if (defaultFile) {
+        this.setState({ selectedFile: defaultFile });
+        await this.loadFileContent(defaultFile);
+      }
+    }
+    catch (error) {
+      // Never swallow the failure: surface it instead of showing an empty editor.
+      DialogService.instance.dataError({
+        message: 'Could not load the experiment files.',
+        data: error && error.toString()
+      });
+    }
+    finally {
+      this.setState({ isLoading: false });
+    }
   }
 
   onChangeSelectedFile(event) {
@@ -90,15 +109,32 @@ export default class TransceiverFunctionEditor extends React.Component {
    * @param {string} file.extension is a file extension
    */
   async loadFileContent(file) {
-    let fileContent = await ExperimentStorageService.instance.getFileText(this.state.experimentName, file.name);
-    const codeMirrorMarkup = await this.defineCodeMirrorMarkup(file.extension);
-    this.fileLoading = true;
-    this.setState({
-      selectedFile: file,
-      code: fileContent,
-      showDialogUnsavedChanges: false,
-      codeMirrorMarkup: codeMirrorMarkup
-    });
+    if (!file) {
+      return;
+    }
+    this.setState({ isLoadingContent: true });
+    try {
+      let fileContent = await ExperimentStorageService.instance.getFileText(this.state.experimentName, file.name);
+      const codeMirrorMarkup = await this.defineCodeMirrorMarkup(file.extension);
+      this.fileLoading = true;
+      this.setState({
+        selectedFile: file,
+        code: fileContent,
+        showDialogUnsavedChanges: false,
+        codeMirrorMarkup: codeMirrorMarkup
+      });
+    }
+    catch (error) {
+      // Previously the load error was swallowed and the editor silently kept
+      // the old content; tell the user instead.
+      DialogService.instance.dataError({
+        message: 'Could not load the file "' + file.name + '".',
+        data: error && error.toString()
+      });
+    }
+    finally {
+      this.setState({ isLoadingContent: false });
+    }
   }
 
   async defineCodeMirrorMarkup(ext) {
@@ -126,20 +162,44 @@ export default class TransceiverFunctionEditor extends React.Component {
   }
 
   async saveTF() {
-    let response = await ExperimentStorageService.instance.setFile(
-      this.state.experimentName, this.state.selectedFile.name, this.state.code);
-    if (response.ok) {
-      this.hasUnsavedChanges = false;
-      this.setState({ textChanges: 'saved' });
-      setTimeout(() => {
-        this.setState({ textChanges: '' });
-      }, 3000);
-      return true;
-    }
-    else {
-      console.error('Error trying to save TF!');
-      console.error(response);
+    // Guard against double-clicks while a save is already in flight.
+    if (this.state.isSaving) {
       return false;
+    }
+    this.setState({ isSaving: true, textChanges: 'saving…' });
+    try {
+      let response = await ExperimentStorageService.instance.setFile(
+        this.state.experimentName, this.state.selectedFile.name, this.state.code);
+      if (response.ok) {
+        this.hasUnsavedChanges = false;
+        this.setState({ textChanges: 'saved' });
+        setTimeout(() => {
+          this.setState({ textChanges: '' });
+        }, 3000);
+        return true;
+      }
+      else {
+        console.error('Error trying to save TF!');
+        console.error(response);
+        // Surface the failure instead of only logging it to the console.
+        DialogService.instance.dataError({
+          message: 'Could not save the file "' + this.state.selectedFile.name + '".',
+          code: response.status
+        });
+        this.setState({ textChanges: 'save failed' });
+        return false;
+      }
+    }
+    catch (error) {
+      DialogService.instance.dataError({
+        message: 'Could not save the file "' + this.state.selectedFile.name + '".',
+        data: error && error.toString()
+      });
+      this.setState({ textChanges: 'save failed' });
+      return false;
+    }
+    finally {
+      this.setState({ isSaving: false });
     }
   }
 
@@ -160,8 +220,9 @@ export default class TransceiverFunctionEditor extends React.Component {
             </select>
             <button
               className='tf-editor-file-ui-item'
+              disabled={this.state.isSaving || this.state.isLoading || this.state.isLoadingContent}
               onClick={() => this.saveTF()}>
-              Save
+              {this.state.isSaving ? 'Saving…' : 'Save'}
             </button>
             <div className={this.hasUnsavedChanges ?
               'tf-editor-text-unsaved' : 'tf-editor-text-saved'}>
@@ -171,6 +232,9 @@ export default class TransceiverFunctionEditor extends React.Component {
         </div>
 
         <div className='tf-editor-codemirror-container'>
+          {(this.state.isLoading || this.state.isLoadingContent) &&
+            <div className='tf-editor-loading'>Loading file…</div>
+          }
           <CodeMirror
             value={this.state.code}
             onChange={(change, viewUpdate) => this.onChangeCodemirror(change, viewUpdate)}

--- a/src/components/user-menu/user-menu.css
+++ b/src/components/user-menu/user-menu.css
@@ -39,3 +39,13 @@
 .user-icon {
   margin-right: 10px;
 }
+
+.user-retry {
+  background: transparent;
+  border: none;
+  color: white;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1em;
+}

--- a/src/components/user-menu/user-menu.js
+++ b/src/components/user-menu/user-menu.js
@@ -15,7 +15,9 @@ export default class UserMenu extends React.Component {
     super();
 
     this.state = {
-      user: null
+      user: null,
+      loading: true,
+      loadError: false
     };
   }
 
@@ -54,20 +56,42 @@ export default class UserMenu extends React.Component {
    * Cleans the user information when the Proxy connection problem trigger is emitted
    */
   onProxyDisconnected = () => {
-    this.setState({ user: null });
+    this.setState({ user: null, loading: false, loadError: true });
   }
 
   /**
-   * Gets the user information through the NrpUserService
+   * Gets the user information through the NrpUserService.
+   * Resolves to a real user, or falls back to an error/retry state after a
+   * timeout, so the menu never hangs on "pending …" forever.
+   *
+   * @param {boolean} force - force a refresh of the cached user
    */
-  async getCurrentUser() {
-    NrpUserService.instance.getCurrentUser().then((currentUser) => {
-      if (!this.cancelGetCurrentUser) {
-        this.setState({
-          user: currentUser
-        });
+  async getCurrentUser(force = false) {
+    this.setState({ loading: true, loadError: false });
+    try {
+      const currentUser = await Promise.race([
+        NrpUserService.instance.getCurrentUser(force),
+        new Promise((resolve, reject) =>
+          setTimeout(() => reject(new Error('timeout')), UserMenu.CONSTANTS.USER_FETCH_TIMEOUT_MS))
+      ]);
+      if (this.cancelGetCurrentUser) {
+        return;
       }
-    });
+      if (currentUser) {
+        this.setState({ user: currentUser, loading: false, loadError: false });
+      }
+      else {
+        // Resolved without a user (request failed inside the service).
+        this.setState({ user: null, loading: false, loadError: true });
+      }
+    }
+    catch (error) {
+      // Timed out or threw: surface an actionable retry instead of hanging.
+      if (this.cancelGetCurrentUser) {
+        return;
+      }
+      this.setState({ user: null, loading: false, loadError: true });
+    }
   }
 
   /**
@@ -89,7 +113,19 @@ export default class UserMenu extends React.Component {
           >
             <div id='user-menu-name' className='user-name'>
               <AccountCircleIcon className='user-icon' />
-              {this.state.user ? this.state.user.displayName : 'pending ...'}
+              {this.state.user
+                ? this.state.user.displayName
+                : this.state.loading
+                  ? 'Loading…'
+                  : <button type='button' className='user-retry'
+                    onClick={(event) => {
+                      // Don't let the retry click toggle the dropdown open.
+                      event.stopPropagation();
+                      this.getCurrentUser(true);
+                    }}>
+                    Unavailable — retry
+                  </button>
+              }
             </div>
           </Dropdown.Toggle>
 
@@ -107,3 +143,8 @@ export default class UserMenu extends React.Component {
     );
   }
 }
+
+UserMenu.CONSTANTS = Object.freeze({
+  // Give up waiting for the identity request after this long and offer a retry.
+  USER_FETCH_TIMEOUT_MS: 10000
+});

--- a/src/components/xpra/xpra-view.css
+++ b/src/components/xpra/xpra-view.css
@@ -16,3 +16,43 @@
 .note-no-streams {
     margin: 20px;
 }
+
+.xpra-iframe-container {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+}
+
+.xpra-iframe-loading {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f5f5f5;
+    color: #555;
+    font-style: italic;
+    z-index: 1;
+}
+
+.xpra-iframe-fallback {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 12px;
+    padding: 20px;
+    text-align: center;
+    color: #842029;
+    background-color: #f8d7da;
+}
+
+.xpra-iframe-retry {
+    padding: 6px 16px;
+    cursor: pointer;
+}

--- a/src/components/xpra/xpra-view.js
+++ b/src/components/xpra/xpra-view.js
@@ -13,7 +13,13 @@ export default class XpraView extends React.Component {
 
     this.state = {
       xpraUrls: ExperimentWorkbenchService.instance.xpraUrls,
-      currentUrl: undefined
+      currentUrl: undefined,
+      // A dead stream renders as a blank frame, so track load progress and
+      // failures explicitly to show a loading state and an error/retry
+      // fallback instead of an empty iframe.
+      iframeLoading: true,
+      iframeError: false,
+      iframeKey: 0
     };
     if (this.state.xpraUrls.length > 0) {
       this.state.currentUrl = this.state.xpraUrls[0];
@@ -25,6 +31,9 @@ export default class XpraView extends React.Component {
       ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
       this.onSimulationStatusUpdated
     );
+    if (this.state.currentUrl) {
+      this.startIframeLoadTimeout();
+    }
   }
 
   componentWillUnmount() {
@@ -34,7 +43,46 @@ export default class XpraView extends React.Component {
       ExperimentWorkbenchService.EVENTS.SIMULATION_STATUS_UPDATED,
       this.onSimulationStatusUpdated
     );
+    this.clearIframeLoadTimeout();
   }
+
+  /**
+   * A cross-origin stream that never loads fires no `onError`, so fall back to
+   * a timeout: if the iframe has not loaded in time, treat it as a failure.
+   */
+  startIframeLoadTimeout() {
+    this.clearIframeLoadTimeout();
+    this.iframeLoadTimeout = setTimeout(() => {
+      if (this.state.iframeLoading) {
+        this.setState({ iframeLoading: false, iframeError: true });
+      }
+    }, XpraView.CONSTANTS.LOAD_TIMEOUT_MS);
+  }
+
+  clearIframeLoadTimeout() {
+    if (this.iframeLoadTimeout) {
+      clearTimeout(this.iframeLoadTimeout);
+      this.iframeLoadTimeout = undefined;
+    }
+  }
+
+  onIframeLoad = () => {
+    this.clearIframeLoadTimeout();
+    this.setState({ iframeLoading: false, iframeError: false });
+  };
+
+  onIframeError = () => {
+    this.clearIframeLoadTimeout();
+    this.setState({ iframeLoading: false, iframeError: true });
+  };
+
+  reloadIframe = () => {
+    // Bump the key to force a fresh iframe element and restart the watchdog.
+    this.setState(
+      (state) => ({ iframeKey: state.iframeKey + 1, iframeLoading: true, iframeError: false }),
+      () => this.startIframeLoadTimeout()
+    );
+  };
 
   onSimulationStatusUpdated = (status) => {
     this.simulationState = status.state;
@@ -42,16 +90,20 @@ export default class XpraView extends React.Component {
       if (ExperimentWorkbenchService.instance.xpraUrls.length > 0) {
         this.setState({
           xpraUrls: ExperimentWorkbenchService.instance.xpraUrls,
-          currentUrl: ExperimentWorkbenchService.instance.xpraUrls[0]
-        });
+          currentUrl: ExperimentWorkbenchService.instance.xpraUrls[0],
+          iframeLoading: true,
+          iframeError: false
+        }, () => this.startIframeLoadTimeout());
       }
     }
   }
 
   onChangeSelectedXpraUrl(event) {
     this.setState({
-      currentUrl: event.target.value
-    });
+      currentUrl: event.target.value,
+      iframeLoading: true,
+      iframeError: false
+    }, () => this.startIframeLoadTimeout());
   }
 
   render() {
@@ -71,8 +123,25 @@ export default class XpraView extends React.Component {
                 })}
               </select>
             </div>
-            <iframe src={this.state.currentUrl + '?printing=No&file_transfer=No&floating_menu=No&sound=No'}
-              title='Xpra' />
+            <div className='xpra-iframe-container'>
+              {this.state.iframeError ?
+                <div className='xpra-iframe-fallback'>
+                  <div>The video stream could not be loaded (the stream may not be ready yet).</div>
+                  <button className='xpra-iframe-retry' onClick={this.reloadIframe}>Retry</button>
+                </div>
+                :
+                <React.Fragment>
+                  {this.state.iframeLoading &&
+                    <div className='xpra-iframe-loading'>Loading stream…</div>
+                  }
+                  <iframe key={this.state.iframeKey}
+                    src={this.state.currentUrl + '?printing=No&file_transfer=No&floating_menu=No&sound=No'}
+                    title='Xpra'
+                    onLoad={this.onIframeLoad}
+                    onError={this.onIframeError} />
+                </React.Fragment>
+              }
+            </div>
           </div>
           :
           <div className='note-no-streams'>No streams available, maybe no simulation has been started yet?</div>
@@ -83,6 +152,9 @@ export default class XpraView extends React.Component {
 }
 
 XpraView.CONSTANTS = Object.freeze({
+  // How long to wait for the stream iframe to load before showing the
+  // error/retry fallback.
+  LOAD_TIMEOUT_MS: 15000,
   TOOL_CONFIG: {
     singleton: true,
     type: SIM_TOOL.TOOL_TYPE.FLEXLAYOUT_TAB,

--- a/src/services/__tests__/authentication-service.test.js
+++ b/src/services/__tests__/authentication-service.test.js
@@ -97,4 +97,16 @@ describe('AuthenticationService', () => {
     spyAuthCollab.mockReturnValue(Promise.reject());
     await expect(AuthenticationService.instance.authenticate({force: true})).rejects.toBe(undefined);
   });
+
+  test('logout() (Collab mode) calls keycloak.logout and clears the local token', () => {
+    AuthenticationService.instance.oidcEnabled = true;
+    const logoutFn = jest.fn();
+    AuthenticationService.instance.keycloakClient = { authenticated: true, logout: logoutFn };
+    const clearSpy = jest.spyOn(AuthenticationService.instance, 'clearStoredLocalToken');
+
+    // Must not throw (previously called a nonexistent Keycloak method).
+    expect(() => AuthenticationService.instance.logout()).not.toThrow();
+    expect(clearSpy).toHaveBeenCalled();
+    expect(logoutFn).toHaveBeenCalled();
+  });
 });

--- a/src/services/__tests__/authentication-service.test.js
+++ b/src/services/__tests__/authentication-service.test.js
@@ -98,6 +98,25 @@ describe('AuthenticationService', () => {
     await expect(AuthenticationService.instance.authenticate({force: true})).rejects.toBe(undefined);
   });
 
+  test('getToken() (Collab mode) awaits the refresh and returns the fresh token', async () => {
+    AuthenticationService.instance.oidcEnabled = true;
+    // The refreshed token only becomes available once updateToken() resolves.
+    // A fire-and-forget refresh would return the stale token instead.
+    const keycloakClient = {
+      token: 'stale-token',
+      updateToken: jest.fn(() =>
+        Promise.resolve(true).then(() => {
+          keycloakClient.token = 'fresh-token';
+          return true;
+        }))
+    };
+    AuthenticationService.instance.keycloakClient = keycloakClient;
+
+    const token = await AuthenticationService.instance.getToken();
+    expect(keycloakClient.updateToken).toHaveBeenCalledWith(30);
+    expect(token).toBe('fresh-token');
+  });
+
   test('logout() (Collab mode) calls keycloak.logout and clears the local token', () => {
     AuthenticationService.instance.oidcEnabled = true;
     const logoutFn = jest.fn();

--- a/src/services/__tests__/mqtt-client-service.test.js
+++ b/src/services/__tests__/mqtt-client-service.test.js
@@ -92,4 +92,39 @@ describe('MqttClientService', () => {
     expect(sub2Token.callback).toHaveBeenCalledTimes(2);
     expect(sub3Token.callback).toHaveBeenCalledTimes(3);
   });
+
+  // EBR2-108: connection loss must be detected and surfaced so the UI can react.
+  test('tracks connection state and surfaces connection loss', () => {
+    const service = MqttClientService.instance;
+    const client = service.client; // mocked EventEmitter
+
+    const onDisconnected = jest.fn();
+    const onReconnecting = jest.fn();
+    const onStateChanged = jest.fn();
+    service.on(MqttClientService.EVENTS.DISCONNECTED, onDisconnected);
+    service.on(MqttClientService.EVENTS.RECONNECTING, onReconnecting);
+    service.on(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, onStateChanged);
+
+    client.emit('connect');
+    expect(service.isConnected()).toBe(true);
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.CONNECTED);
+
+    // A close after being connected is a real connection loss.
+    client.emit('close');
+    expect(service.isConnected()).toBe(false);
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.DISCONNECTED);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+
+    // Reconnect attempts are tracked and surfaced.
+    client.emit('reconnect');
+    expect(service.getConnectionState()).toBe(MqttClientService.CONNECTION_STATES.RECONNECTING);
+    expect(onReconnecting).toHaveBeenCalledTimes(1);
+
+    // connect -> close -> reconnect = 3 state transitions
+    expect(onStateChanged).toHaveBeenCalledTimes(3);
+
+    service.removeListener(MqttClientService.EVENTS.DISCONNECTED, onDisconnected);
+    service.removeListener(MqttClientService.EVENTS.RECONNECTING, onReconnecting);
+    service.removeListener(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, onStateChanged);
+  });
 });

--- a/src/services/__tests__/mqtt-client-service.test.js
+++ b/src/services/__tests__/mqtt-client-service.test.js
@@ -24,7 +24,10 @@ describe('MqttClientService', () => {
 
   let unsubscribeAndValidate = (token) => {
     MqttClientService.instance.unsubscribe(token);
-    expect(MqttClientService.instance.subTokensMap.get(token.topic).includes(token)).toBeFalsy();
+    // After unsubscribe the token must no longer be present. The map entry is
+    // deleted entirely once a topic has no subscribers left.
+    let remaining = MqttClientService.instance.subTokensMap.get(token.topic);
+    expect(remaining === undefined || !remaining.includes(token)).toBeTruthy();
   };
 
   test('sub/unsub', () => {
@@ -38,6 +41,11 @@ describe('MqttClientService', () => {
         // Your custom mock logic for the 'subscribe' function
         console.log(`Mocked subscribe function called with topic: ${topic}`);
         // You can customize the behavior or return value of the 'subscribe' function here
+      });
+      // Mock the 'unsubscribe' function so we can assert the broker subscription
+      // is actually cancelled when the last subscriber leaves.
+      mqttClient.unsubscribe = jest.fn().mockImplementation((topic, callback) => {
+        console.log(`Mocked unsubscribe function called with topic: ${topic}`);
       });
 
       return mqttClient;
@@ -53,6 +61,8 @@ describe('MqttClientService', () => {
     let sub3Callback = jest.fn();
     let sub3Token = subscribeTopicAndValidate(topicB, sub3Callback);
 
+    let client = MqttClientService.instance.client;
+
     expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(2);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
 
@@ -65,6 +75,8 @@ describe('MqttClientService', () => {
     unsubscribeAndValidate(sub1Token);
     expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(1);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
+    // topicA still has a subscriber, so the broker subscription must remain.
+    expect(client.unsubscribe).not.toHaveBeenCalled();
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});
@@ -73,8 +85,10 @@ describe('MqttClientService', () => {
     expect(sub3Token.callback).toHaveBeenCalledTimes(2);
 
     unsubscribeAndValidate(sub2Token);
-    expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(0);
+    // Last subscriber for topicA gone: map entry deleted and broker unsubscribed.
+    expect(MqttClientService.instance.subTokensMap.has(topicA)).toBe(false);
     expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(1);
+    expect(client.unsubscribe).toHaveBeenCalledWith(topicA, expect.any(Function));
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});
@@ -83,8 +97,9 @@ describe('MqttClientService', () => {
     expect(sub3Token.callback).toHaveBeenCalledTimes(3);
 
     unsubscribeAndValidate(sub3Token);
-    expect(MqttClientService.instance.subTokensMap.get(topicA).length).toBe(0);
-    expect(MqttClientService.instance.subTokensMap.get(topicB).length).toBe(0);
+    expect(MqttClientService.instance.subTokensMap.has(topicA)).toBe(false);
+    expect(MqttClientService.instance.subTokensMap.has(topicB)).toBe(false);
+    expect(client.unsubscribe).toHaveBeenCalledWith(topicB, expect.any(Function));
 
     MqttClientService.instance.onMessage(topicA, {});
     MqttClientService.instance.onMessage(topicB, {});

--- a/src/services/__tests__/roslib-service.test.js
+++ b/src/services/__tests__/roslib-service.test.js
@@ -49,6 +49,18 @@ describe('RoslibService (EBR2-108)', () => {
     // still a single cache entry for the clean URL
     expect(RoslibService.instance.connections.size).toBe(1);
   });
+
+  test('createService uses the provided ROS service type, not the service name', () => {
+    const connection = {};
+    RoslibService.instance.createService(connection, '/my_service', 'my_pkg/MySrv', { extra: 1 });
+
+    expect(ROSLIB.Service).toHaveBeenCalledWith({
+      ros: connection,
+      name: '/my_service',
+      serviceType: 'my_pkg/MySrv',
+      extra: 1
+    });
+  });
 });
 
 describe.skip('RoslibService', () => {

--- a/src/services/__tests__/roslib-service.test.js
+++ b/src/services/__tests__/roslib-service.test.js
@@ -6,6 +6,50 @@ import 'jest-fetch-mock';
 
 import * as ROSLIB from 'roslib';
 import RoslibService from '../roslib-service';
+import AuthenticationService from '../authentication-service';
+
+// Auto-mock roslib so ROSLIB.Ros does not open a real socket (which crashes the
+// node test process — the reason the legacy suite below is skipped).
+jest.mock('roslib');
+
+// EBR2-108: the connection cache must be keyed by the clean URL (not a
+// token-bearing URL) and a refreshed auth token must produce a fresh
+// connection; createService must use a real ROS service type, not the name.
+describe('RoslibService (EBR2-108)', () => {
+  afterEach(() => {
+    // Drop cached connections so each test starts clean (singleton state).
+    RoslibService.instance.connections.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('caches connections by clean URL and reuses them for the same token', async () => {
+    jest.spyOn(AuthenticationService.instance, 'getToken').mockReturnValue('tok-1');
+
+    const c1 = await RoslibService.instance.getConnection('ws://ros');
+    const c2 = await RoslibService.instance.getConnection('ws://ros');
+
+    expect(c1).toBe(c2);
+    expect(ROSLIB.Ros).toHaveBeenCalledTimes(1);
+    // token baked into the connection URL, not into the cache key
+    expect(ROSLIB.Ros).toHaveBeenCalledWith({ url: 'ws://ros?token=tok-1' });
+    // the map key is the clean URL
+    expect(RoslibService.instance.connections.has('ws://ros')).toBe(true);
+  });
+
+  test('recreates the connection when the auth token changes', async () => {
+    const getTokenSpy = jest.spyOn(AuthenticationService.instance, 'getToken');
+
+    getTokenSpy.mockReturnValue('tok-A');
+    await RoslibService.instance.getConnection('ws://ros');
+    getTokenSpy.mockReturnValue('tok-B');
+    await RoslibService.instance.getConnection('ws://ros');
+
+    expect(ROSLIB.Ros).toHaveBeenCalledTimes(2);
+    expect(ROSLIB.Ros).toHaveBeenLastCalledWith({ url: 'ws://ros?token=tok-B' });
+    // still a single cache entry for the clean URL
+    expect(RoslibService.instance.connections.size).toBe(1);
+  });
+});
 
 describe.skip('RoslibService', () => {
   test('makes sure that invoking the constructor fails with the right message', () => {

--- a/src/services/authentication-service.js
+++ b/src/services/authentication-service.js
@@ -61,18 +61,20 @@ class AuthenticationService {
     return this.promiseInitialized;
   }
 
-  getToken() {
+  async getToken() {
     if (this.oidcEnabled) {
       if (this.keycloakClient && this.keycloakClient.token) {
-        this.keycloakClient
-          .updateToken(30).then(refreshed => {
-            if (refreshed) {
-              console.info('token refreshed');
-            }
-          })
-          .catch(() => {
-            console.error('Failed to refresh token');
-          });
+        // Await the refresh so callers get an up-to-date token. The previous
+        // fire-and-forget refresh returned the possibly-stale current token.
+        try {
+          const refreshed = await this.keycloakClient.updateToken(30);
+          if (refreshed) {
+            console.info('token refreshed');
+          }
+        }
+        catch (error) {
+          console.error('Failed to refresh token');
+        }
         return this.keycloakClient.token;
       }
       else {

--- a/src/services/authentication-service.js
+++ b/src/services/authentication-service.js
@@ -87,8 +87,11 @@ class AuthenticationService {
   logout() {
     if (this.oidcEnabled) {
       if (this.keycloakClient && this.keycloakClient.authenticated) {
-        this.keycloakClient.logout();
-        this.keycloakClient.clearStoredLocalToken();
+        // Clear our own stored token, then end the OIDC session. The previous
+        // code called this.keycloakClient.clearStoredLocalToken(), which is not
+        // a Keycloak method and threw, aborting the logout.
+        this.clearStoredLocalToken();
+        return this.keycloakClient.logout({ redirectUri: window.location.origin });
       }
       else {
         console.error('Client is not authenticated');

--- a/src/services/experiments/execution/__tests__/running-simulation-service.test.js
+++ b/src/services/experiments/execution/__tests__/running-simulation-service.test.js
@@ -132,3 +132,49 @@ describe.skip('RunningSimulationService', () => {
     expect(DialogService.instance.simulationError).toHaveBeenCalled();
   });
 });
+
+// EBR2-108: simulationReady used to poll forever after a creationUniqueID
+// mismatch (it rejected but kept re-scheduling) and had no upper bound. This
+// suite covers the bounded/bailout behavior. A tiny interval and small
+// maxAttempts keep the tests fast and deterministic.
+describe('RunningSimulationService.simulationReady bailouts (EBR2-108)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('rejects and stops polling on a creationUniqueID mismatch', async () => {
+    const getSpy = jest.spyOn(RunningSimulationService.instance, 'httpRequestGET')
+      .mockImplementation(() => Promise.resolve({
+        json: () => Promise.resolve([
+          { state: EXPERIMENT_STATE.PAUSED, creationUniqueID: 'real-id' }
+        ])
+      }));
+
+    await expect(
+      RunningSimulationService.instance.simulationReady(
+        'mock-server-url', 'wrong-id', { interval: 1, maxAttempts: 10 })
+    ).rejects.toThrow('creationUniqueID mismatch');
+
+    // A mismatch is terminal: the poll must not be re-scheduled.
+    const callsAfterReject = getSpy.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(getSpy.mock.calls.length).toBe(callsAfterReject);
+    expect(callsAfterReject).toBe(1);
+  });
+
+  test('rejects with a timeout after maxAttempts while stuck pending', async () => {
+    const getSpy = jest.spyOn(RunningSimulationService.instance, 'httpRequestGET')
+      .mockImplementation(() => Promise.resolve({
+        json: () => Promise.resolve([
+          { state: EXPERIMENT_STATE.CREATED, creationUniqueID: 'real-id' }
+        ])
+      }));
+
+    await expect(
+      RunningSimulationService.instance.simulationReady(
+        'mock-server-url', 'real-id', { interval: 1, maxAttempts: 3 })
+    ).rejects.toThrow('Timed out');
+
+    expect(getSpy.mock.calls.length).toBe(3);
+  });
+});

--- a/src/services/experiments/execution/__tests__/server-resources-service.test.js
+++ b/src/services/experiments/execution/__tests__/server-resources-service.test.js
@@ -72,7 +72,10 @@ describe('ModelsStorageService', () => {
     });
 
     jest.spyOn(DialogService.instance, 'networkError');
-    serverConfig = await ServerResourcesService.instance.getServerConfig('test-server-id');
+    // getServerConfig must reject on failure (not resolve with the error) so the
+    // launch flow does not proceed on garbage.
+    await expect(ServerResourcesService.instance.getServerConfig('test-server-id'))
+      .rejects.toMatchObject({ message: 'getServerConfig request rejected' });
     expect(DialogService.instance.networkError).toHaveBeenCalled();
   });
 

--- a/src/services/experiments/execution/running-simulation-service.js
+++ b/src/services/experiments/execution/running-simulation-service.js
@@ -6,6 +6,10 @@ let _instance = null;
 const SINGLETON_ENFORCER = Symbol();
 
 const INTERVAL_CHECK_SIMULATION_READY = 1000;
+// Upper bound on the number of polls before giving up, so simulationReady can
+// never spin forever (e.g. a server stuck in a pending state or a mismatching
+// creationUniqueID). ~60 polls * 1s ≈ 1 minute.
+const MAX_CHECK_SIMULATION_READY_ATTEMPTS = 60;
 
 /**
  * Service handling state and info of running simulations.
@@ -30,12 +34,18 @@ class SimulationService extends HttpService {
    * Check whether a simulation on a server is ready to be started.
    * @param {string} serverURL - URL of the server where simulation should be run
    * @param {string} creationUniqueID - Unique ID generated while trying to launch experiment
+   * @param {object} [options] - optional overrides ({ interval, maxAttempts }), mainly for testing
    * @returns {Promise} Whether simulation is ready to start
    */
-  simulationReady(serverURL, creationUniqueID) {
+  simulationReady(serverURL, creationUniqueID, options = {}) {
+    const interval = options.interval || INTERVAL_CHECK_SIMULATION_READY;
+    const maxAttempts = options.maxAttempts || MAX_CHECK_SIMULATION_READY_ATTEMPTS;
+
     return new Promise((resolve, reject) => {
+      let attempts = 0;
       let verifySimulation = () => {
         setTimeout(() => {
+          attempts++;
           this.httpRequestGET(serverURL + '/simulation')
             .then(async (reponse) => {
               let continueVerify = true;
@@ -51,7 +61,11 @@ class SimulationService extends HttpService {
                     resolve(simulations[last]);
                   }
                   else {
-                    reject();
+                    // A mismatching creationUniqueID means this is not our
+                    // simulation and it never will be. Stop polling and reject
+                    // instead of spinning forever.
+                    continueVerify = false;
+                    reject(new Error('Simulation creationUniqueID mismatch'));
                   }
                 }
                 else if (state === EXPERIMENT_STATE.HALTED || state === EXPERIMENT_STATE.FAILED) {
@@ -61,11 +75,16 @@ class SimulationService extends HttpService {
               }
 
               if (continueVerify) {
-                verifySimulation();
+                if (attempts >= maxAttempts) {
+                  reject(new Error('Timed out waiting for the simulation to become ready'));
+                }
+                else {
+                  verifySimulation();
+                }
               }
             })
             .catch(reject);
-        }, INTERVAL_CHECK_SIMULATION_READY);
+        }, interval);
       };
 
       verifySimulation();

--- a/src/services/experiments/execution/server-resources-service.js
+++ b/src/services/experiments/execution/server-resources-service.js
@@ -89,7 +89,10 @@ class ServerResourcesService extends HttpProxyService {
       .catch((error) => {
         error = error || { message: 'getServerConfig request rejected' };
         DialogService.instance.networkError(error);
-        return error;
+        // Reject instead of resolving with the error object: callers (e.g. the
+        // experiment launch flow) treat a resolved value as a valid server
+        // config and would otherwise proceed to launch on garbage.
+        return Promise.reject(error);
       });
   }
 }

--- a/src/services/experiments/files/__tests__/import-experiment-service.test.js
+++ b/src/services/experiments/files/__tests__/import-experiment-service.test.js
@@ -33,3 +33,23 @@ describe.skip('ImportExperimentService', () => {
       new Response(JSON.stringify(MockScanStorageResponse)))).toStrictEqual(scanStorageResponse);
   });
 });
+
+// EBR2-108: getImportZipResponses used `await responses.forEach(async ...)`,
+// which awaits forEach's undefined return, so the arrays were still empty when
+// returned and the confirmation dialog showed blank names.
+describe('ImportExperimentService.getImportZipResponses (EBR2-108)', () => {
+  test('surfaces the real file names in order without blanks', async () => {
+    const raw = [
+      { zipBaseFolderName: 'exp_a', destFolderName: 'dest_a', newName: 'Imported A' },
+      { zipBaseFolderName: 'exp_b', destFolderName: 'dest_b', newName: 'Imported B' }
+    ];
+    const responses = raw.map((r) => new Response(JSON.stringify(r)));
+
+    const result = await ImportExperimentService.instance.getImportZipResponses(responses);
+
+    expect(result.numberOfZips).toBe(2);
+    expect(result.zipBaseFolderName).toEqual(['exp_a', 'exp_b']);
+    expect(result.destFolderName).toEqual(['dest_a', 'dest_b']);
+    expect(result.newExpName).toEqual(['Imported A', 'Imported B']);
+  });
+});

--- a/src/services/experiments/files/import-experiment-service.js
+++ b/src/services/experiments/files/import-experiment-service.js
@@ -59,8 +59,12 @@ export default class ImportExperimentService extends HttpProxyService {
       newExpName: []
     };
     importZipResponses.numberOfZips = responses.length;
-    await responses.forEach(async response =>{
-      response = await response.json();
+    // Await every parsed body before returning. The previous `await
+    // responses.forEach(async ...)` awaited forEach's undefined return, so the
+    // arrays were still empty when returned and the confirmation showed blank
+    // names. Parse in order so names line up across the arrays.
+    const parsedResponses = await Promise.all(responses.map((response) => response.json()));
+    parsedResponses.forEach((response) => {
       importZipResponses['zipBaseFolderName'].push(response['zipBaseFolderName']);
       importZipResponses['destFolderName'].push(response['destFolderName']);
       importZipResponses['newExpName'].push(response['newName']);

--- a/src/services/http-service.js
+++ b/src/services/http-service.js
@@ -46,7 +46,7 @@ export class HttpService extends EventEmitter {
   async performRequest(url, options, data){
     // Add authorization headerasync (url)
     await AuthenticationService.instance.promiseInitialized;
-    let token = AuthenticationService.instance.getToken();
+    let token = await AuthenticationService.instance.getToken();
     options.headers.Authorization = 'Bearer ' + token;
     if (data) {
       options.body = data;

--- a/src/services/models/__tests__/models-storage-service.test.js
+++ b/src/services/models/__tests__/models-storage-service.test.js
@@ -52,6 +52,30 @@ describe('ModelsStorageService', () => {
     expect(response.type).toBe('robots');
   });
 
+  test('getTemplateModels caches per model type and bails on an invalid type', async () => {
+    let modelsService = ModelsStorageService.instance;
+    modelsService.modelsCache = new Map(); // clean cache (singleton)
+
+    // Invalid model type: bail out, show a data error, do NOT fetch.
+    jest.spyOn(DialogService.instance, 'dataError').mockImplementation();
+    const getSpy = jest.spyOn(modelsService, 'httpRequestGET');
+    let invalid = await modelsService.getTemplateModels(false, 'notAModel', false);
+    expect(invalid).toBeUndefined();
+    expect(DialogService.instance.dataError).toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+
+    // Fetch two distinct types; each is cached under its own key.
+    await modelsService.getTemplateModels(false, 'robots', false);
+    await modelsService.getTemplateModels(false, 'brains', false);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+
+    // A repeated request for a cached type is served from cache (no new fetch).
+    await modelsService.getTemplateModels(false, 'robots', false);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    expect(modelsService.modelsCache.has('template:robots')).toBe(true);
+    expect(modelsService.modelsCache.has('template:brains')).toBe(true);
+  });
+
   test('getCustomModelsByUser function', async () => {
 
     let modelsService = ModelsStorageService.instance;

--- a/src/services/models/models-storage-service.js
+++ b/src/services/models/models-storage-service.js
@@ -20,6 +20,9 @@ class ModelsStorageService extends HttpProxyService {
     if (enforcer !== SINGLETON_ENFORCER) {
       throw new Error('Use ' + this.constructor.name + '.instance');
     }
+    // Cache keyed by "<template|custom>:<modelType>" so different model types
+    // (and templates vs custom models) never overwrite each other.
+    this.modelsCache = new Map();
   }
 
   static get instance() {
@@ -42,27 +45,32 @@ class ModelsStorageService extends HttpProxyService {
    * @return models - the list of template models
    */
   async getTemplateModels(forceUpdate = false, modelType, allCustomModels = false) {
-    if (!this.models || forceUpdate) {
-      try {
-        this.verifyModelType(modelType);
-      }
-      catch (error) {
-        DialogService.instance.dataError(error);
-      }
-
-      try {
-        const modelsWithTypeURL = allCustomModels ?
-          `${allCustomModelsURL}/${modelType}` :
-          `${storageModelsURL}/${modelType}`;
-        this.models = await (await this.httpRequestGET(modelsWithTypeURL)).json();
-      }
-      catch (error) {
-        DialogService.instance.networkError(error);
-      }
-
+    // Bail out on an invalid model type instead of firing a request with a bad
+    // path (which previously kept fetching with the invalid modelType).
+    try {
+      this.verifyModelType(modelType);
+    }
+    catch (error) {
+      DialogService.instance.dataError(error);
+      return;
     }
 
-    return this.models;
+    const cacheKey = (allCustomModels ? 'custom:' : 'template:') + modelType;
+    if (!forceUpdate && this.modelsCache.has(cacheKey)) {
+      return this.modelsCache.get(cacheKey);
+    }
+
+    try {
+      const modelsWithTypeURL = allCustomModels ?
+        `${allCustomModelsURL}/${modelType}` :
+        `${storageModelsURL}/${modelType}`;
+      const models = await (await this.httpRequestGET(modelsWithTypeURL)).json();
+      this.modelsCache.set(cacheKey, models);
+      return models;
+    }
+    catch (error) {
+      DialogService.instance.networkError(error);
+    }
   }
 
   /**

--- a/src/services/mqtt-client-service.js
+++ b/src/services/mqtt-client-service.js
@@ -31,6 +31,7 @@ export default class MqttClientService extends EventEmitter {
     this.state = {
       isConnected: false
     };
+    this.connectionState = MqttClientService.CONNECTION_STATES.DISCONNECTED;
 
     this.subTokensMap = new Map();
 
@@ -51,7 +52,15 @@ export default class MqttClientService extends EventEmitter {
   }
 
   isConnected() {
-    return this.client.connected;
+    return this.connectionState === MqttClientService.CONNECTION_STATES.CONNECTED;
+  }
+
+  /**
+   * @returns {string} the current connection state, one of
+   * MqttClientService.CONNECTION_STATES.
+   */
+  getConnectionState() {
+    return this.connectionState;
   }
 
   getBrokerURL() {
@@ -65,27 +74,70 @@ export default class MqttClientService extends EventEmitter {
   connect() {
     console.info('MQTT connecting to ' + this.mqttBrokerUrl + ' ...');
     this.client = mqtt.connect(this.mqttBrokerUrl, { clientId: 'nrp-frontend_' + uuidv4() });
-    this.client.on('connect', () => {
-      this.onConnect();
-    });
-    this.client.on('error', this.onError);
-    // TODO: fetch disconnection event properly
-    this.client.on('disconnect', () => {
-      console.info('... MQTT disconnected');
-      this.emit(MqttClientService.EVENTS.DISCONNECTED);
-    });
+    // Track the full lifecycle so a lost connection is actually detected and
+    // surfaced (previously only 'connect' and a bare 'disconnect' were handled,
+    // so drops/offline/reconnect went unnoticed).
+    this.client.on('connect', () => this.onConnect());
+    this.client.on('reconnect', () => this.onReconnect());
+    this.client.on('close', () => this.onClose());
+    this.client.on('offline', () => this.onOffline());
+    this.client.on('error', (error) => this.onError(error));
+    this.client.on('disconnect', () => this.onDisconnect());
     this.client.on('message', (topic, message) => {
       this.onMessage(topic, message);
     });
   }
 
+  /**
+   * Update the tracked connection state and notify listeners. Emits a single
+   * DISCONNECTED event when an established connection is lost.
+   *
+   * @param {string} state one of MqttClientService.CONNECTION_STATES
+   */
+  setConnectionState(state) {
+    const previous = this.connectionState;
+    if (previous === state) {
+      return;
+    }
+    this.connectionState = state;
+    this.state.isConnected = (state === MqttClientService.CONNECTION_STATES.CONNECTED);
+    this.emit(MqttClientService.EVENTS.CONNECTION_STATE_CHANGED, state);
+    if (previous === MqttClientService.CONNECTION_STATES.CONNECTED &&
+      state !== MqttClientService.CONNECTION_STATES.CONNECTED) {
+      this.emit(MqttClientService.EVENTS.DISCONNECTED, state);
+    }
+  }
+
   onError(error) {
     console.error(error);
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.ERROR);
+    this.emit(MqttClientService.EVENTS.ERROR, error);
+  }
+
+  onReconnect() {
+    console.info('... MQTT reconnecting');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.RECONNECTING);
+    this.emit(MqttClientService.EVENTS.RECONNECTING);
+  }
+
+  onClose() {
+    console.info('... MQTT connection closed');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.DISCONNECTED);
+  }
+
+  onOffline() {
+    console.info('... MQTT offline');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.OFFLINE);
+  }
+
+  onDisconnect() {
+    console.info('... MQTT disconnected');
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.DISCONNECTED);
   }
 
   onConnect() {
     console.info('... MQTT connected');
-    console.info(this.client);
+    this.setConnectionState(MqttClientService.CONNECTION_STATES.CONNECTED);
     // TODO: filter nrp messages
     this.client.subscribe('#', (err) => {
       if (err) {
@@ -224,5 +276,16 @@ export default class MqttClientService extends EventEmitter {
 
 MqttClientService.EVENTS = Object.freeze({
   CONNECTED: 'CONNECTED',
-  DISCONNECTED: 'DISCONNECTED'
+  DISCONNECTED: 'DISCONNECTED',
+  RECONNECTING: 'RECONNECTING',
+  ERROR: 'ERROR',
+  CONNECTION_STATE_CHANGED: 'CONNECTION_STATE_CHANGED'
+});
+
+MqttClientService.CONNECTION_STATES = Object.freeze({
+  CONNECTED: 'connected',
+  RECONNECTING: 'reconnecting',
+  OFFLINE: 'offline',
+  DISCONNECTED: 'disconnected',
+  ERROR: 'error'
 });

--- a/src/services/mqtt-client-service.js
+++ b/src/services/mqtt-client-service.js
@@ -255,6 +255,19 @@ export default class MqttClientService extends EventEmitter {
       else {
         console.warn('Your provided token could not be found in the subscription list');
       }
+      // When the last subscriber for a topic is removed, actually cancel the
+      // broker subscription and drop the map entry, instead of leaving an
+      // empty array behind (which leaked entries and kept the broker sending).
+      if (tokens.length === 0) {
+        if (this.client && typeof this.client.unsubscribe === 'function') {
+          this.client.unsubscribe(unsubToken.topic, (err) => {
+            if (err) {
+              console.error(err);
+            }
+          });
+        }
+        this.subTokensMap.delete(unsubToken.topic);
+      }
     }
     else{
       console.warn('The topic ' + unsubToken.topic + ' was not found');

--- a/src/services/proxy/__tests__/http-proxy-service.test.js
+++ b/src/services/proxy/__tests__/http-proxy-service.test.js
@@ -3,7 +3,7 @@
 */
 import '@testing-library/jest-dom';
 
-import { HttpProxyService } from '../http-proxy-service';
+import { HttpProxyService, NRPProxyError } from '../http-proxy-service';
 import EventProxyService from '../event-proxy-service';
 jest.mock('../../authentication-service.js');
 
@@ -127,8 +127,12 @@ describe('HttpProxyService', () => {
     const emitDisconnectedSpy = jest.spyOn(EventProxyService.instance, 'emitDisconnected');
     const emitConnectedSpy = jest.spyOn(EventProxyService.instance, 'emitConnected');
 
-    // The first 2 requests should be 404 but not emit DISCONNECTED
-    expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
+    // Sub-threshold failures resolve to a real Response object (503), never a
+    // synthesized 404 or a non-Response value, and do not emit DISCONNECTED.
+    let firstFailure = await httpService.httpRequestGET(mockEndpoint);
+    expect(firstFailure).toBeInstanceOf(Response);
+    expect(firstFailure.ok).toBe(false);
+    expect(firstFailure.status).toBe(503);
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     // The OK request should reset the counter
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(true);
@@ -137,11 +141,9 @@ describe('HttpProxyService', () => {
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     expect((await httpService.httpRequestGET(mockEndpoint)).ok).toBe(false);
     expect(emitDisconnectedSpy).not.toHaveBeenCalled();
-    try {
-      await httpService.httpRequestGET(mockEndpoint);
-    }
-    catch (error) {
-      expect(emitDisconnectedSpy).toHaveBeenCalledTimes(1);
-    }
+    // On the 3rd consecutive failure the request rejects with an NRPProxyError
+    // (explicit signalling) and DISCONNECTED is emitted exactly once.
+    await expect(httpService.httpRequestGET(mockEndpoint)).rejects.toBeInstanceOf(NRPProxyError);
+    expect(emitDisconnectedSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/proxy/__tests__/nrp-user-service.test.js
+++ b/src/services/proxy/__tests__/nrp-user-service.test.js
@@ -101,6 +101,26 @@ describe('NrpUserService', () => {
     expect(groups).toBeDefined();
   });
 
+  test('does not cache a failed user groups request and retries', async () => {
+    // start from a clean cache
+    NrpUserService.instance.currentUserGroups = undefined;
+
+    // first call fails: must not cache the failure, degrade to an empty list
+    jest.spyOn(NrpUserService.instance, 'httpRequestGET')
+      .mockImplementationOnce(async () => {
+        throw new Error('Test error');
+      });
+    let groups = await NrpUserService.instance.getCurrentUserGroups();
+    expect(groups).toEqual([]);
+    expect(NrpUserService.instance.currentUserGroups).toBeFalsy();
+
+    // second call (network restored via MSW) fetches again and succeeds
+    groups = await NrpUserService.instance.getCurrentUserGroups();
+    expect(Array.isArray(groups)).toBe(true);
+    expect(groups.length).toBeGreaterThan(0);
+    expect(NrpUserService.instance.currentUserGroups).toBeTruthy();
+  });
+
   test('can determine group membership', async () => {
     expect(await NrpUserService.instance.isGroupMember(MockUserGroups[0].name)).toBe(true);
     expect(await NrpUserService.instance.isGroupMember('not-a-group')).toBe(false);

--- a/src/services/proxy/event-proxy-service.js
+++ b/src/services/proxy/event-proxy-service.js
@@ -7,7 +7,6 @@
  */
 
 import { EventEmitter } from 'events';
-import { NRPProxyError } from './http-proxy-service';
 import DialogService from '../dialog-service';
 
 let _instance = null;
@@ -93,23 +92,23 @@ export default class EventProxyService extends EventEmitter {
 
 
   /**
-   * Throws NRPProxyError exception when connection is lost.
+   * Updates the connection state when the proxy connection is lost.
    *
    * @listens EventProxyService.EVENTS.DISCONNECTED
    *
-   * @param {object} obj is a objest with `code` and `data` fields
-   * which are displayed in the dialog together with the `stack`
+   * @param {object} obj is an object with `code` and `data` fields describing
+   * the failure; it is recorded for diagnostics and consumed by listeners.
    */
   onDisconnected(obj){
     this.connected = false;
     if (!this.initialized) {
       this.initialized = true;
     }
-    throw new NRPProxyError(
-      'Failed to communicate with proxy.',
-      obj.code,//requestURL.href,
-      obj.data//JSON.stringify(options, null, 4)
-    );
+    // Record the last disconnect reason instead of throwing from inside the
+    // listener. Throwing here made the failure surface as an exception
+    // propagating out of EventEmitter.emit(), which was fragile. The failure
+    // is now signalled explicitly by HttpProxyService.performRequest.
+    this.lastError = obj || null;
   }
 
 }

--- a/src/services/proxy/http-proxy-service.js
+++ b/src/services/proxy/http-proxy-service.js
@@ -58,7 +58,7 @@ export class HttpProxyService extends HttpService {
     const requestURL = new URL(path, this.proxyURL);
     try {
       await AuthenticationService.instance.promiseInitialized;
-      let token = AuthenticationService.instance.getToken();
+      let token = await AuthenticationService.instance.getToken();
       options.headers.Authorization = 'Bearer ' + token;
     }
     catch (error) {

--- a/src/services/proxy/http-proxy-service.js
+++ b/src/services/proxy/http-proxy-service.js
@@ -63,7 +63,13 @@ export class HttpProxyService extends HttpService {
     }
     catch (error) {
       console.error(error);
-      return false;
+      // Never return a non-Response value (used to return `false`): callers
+      // expect either a Response or a thrown NRPProxyError.
+      throw new NRPProxyError(
+        'Failed to obtain an authentication token for the proxy request.',
+        requestURL.href,
+        error && error.message
+      );
     }
 
     // add data to the request
@@ -80,15 +86,29 @@ export class HttpProxyService extends HttpService {
     }
     catch (error) {
       this.failedRequestsCount++;
+      const disconnectInfo = {
+        code: requestURL.href,
+        data:
+          'Error occured: \n' + (error && error.message) +
+          '\nwith options:\n' + JSON.stringify(options, null, 4)
+      };
       if (this.failedRequestsCount >= MAX_FAILED_REQUESTS) {
-        EventProxyService.instance.emitDisconnected({
-          code: requestURL.href,
-          data:
-            'Error occured: \n' + error.message + '\nwith options:\n' + JSON.stringify(options, null, 4)
-        });
+        EventProxyService.instance.emitDisconnected(disconnectInfo);
+        // Signal the persistent failure explicitly rather than relying on the
+        // disconnect event listener to throw.
+        throw new NRPProxyError(
+          'Failed to communicate with proxy.',
+          disconnectInfo.code,
+          disconnectInfo.data
+        );
       }
-      // TODO: the Error is thrown (emitDisconnected) before the response is generated ??
-      return new Response(JSON.stringify([]), {status: 404});
+      // Below the failure threshold, return a real Response (Service
+      // Unavailable) so callers uniformly get a Response object with a false
+      // `ok` flag, instead of a synthesized 404 that masks a network error.
+      return new Response(
+        JSON.stringify({ error: 'Proxy request failed', code: requestURL.href }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     // error handling

--- a/src/services/proxy/nrp-user-service.js
+++ b/src/services/proxy/nrp-user-service.js
@@ -88,12 +88,24 @@ class NrpUserService extends HttpProxyService {
   /**
    * Gives you the currently defined user groups.
    *
+   * @param {boolean} force - force a refresh instead of using the cached value
    * @return currentUserGroups - the user groups currently belonging to
    */
-  async getCurrentUserGroups() {
-    if (!this.currentUserGroups) {
-      let response = await this.httpRequestGET(IDENTITY_ME_GROUPS_URL);
-      this.currentUserGroups = response.json();
+  async getCurrentUserGroups(force = false) {
+    if (force || !this.currentUserGroups) {
+      try {
+        let response = await this.httpRequestGET(IDENTITY_ME_GROUPS_URL);
+        // Await the parsed body: the previous code cached the unresolved
+        // promise returned by response.json().
+        this.currentUserGroups = await response.json();
+      }
+      catch (error) {
+        // Do NOT cache a failure — clear it so the next call retries — and
+        // return an empty group list so callers degrade gracefully.
+        this.currentUserGroups = undefined;
+        this.emit(NrpUserService.EVENTS.DISCONNECTED);
+        return [];
+      }
     }
 
     return this.currentUserGroups;

--- a/src/services/roslib-service.js
+++ b/src/services/roslib-service.js
@@ -29,14 +29,25 @@ class RoslibService {
   /**
    * Create a new connection or return an existing one to a ROS websocket.
    * @param {string} url - URL of the ROS websocket to connect to
+   * @returns {Promise<object>} the ROSLIB.Ros connection
    */
-  getConnection(url) {
-    if (!this.connections.has(url)) {
-      let urlWithAuth = url + '?token=' + AuthenticationService.instance.getToken();
-      this.connections.set(url, new ROSLIB.Ros({ url: urlWithAuth }));
+  async getConnection(url) {
+    const token = await AuthenticationService.instance.getToken();
+    const cached = this.connections.get(url);
+    // The cache is keyed by the clean URL, never by the token-bearing URL, so a
+    // refreshed token does not leak a second cached connection. When the token
+    // changes we recreate the connection so the new token reaches the ROS
+    // websocket (which bakes the token into its connection URL and would
+    // otherwise keep reconnecting with a stale/expired token).
+    if (!cached || cached.token !== token) {
+      if (cached && cached.ros && typeof cached.ros.close === 'function') {
+        cached.ros.close();
+      }
+      let urlWithAuth = url + '?token=' + token;
+      this.connections.set(url, { ros: new ROSLIB.Ros({ url: urlWithAuth }), token });
     }
 
-    return this.connections.get(url);
+    return this.connections.get(url).ros;
   };
 
   /**

--- a/src/services/roslib-service.js
+++ b/src/services/roslib-service.js
@@ -74,13 +74,22 @@ class RoslibService {
     return this.createTopic(connection, topicName, 'std_msgs/String');
   };
 
-  createService(connection, serviceName, additionalOptions) {
+  /**
+   * Create a new ROSLIB.Service.
+   * @param {object} connection - the ROSLIB.Ros connection
+   * @param {string} serviceName - name of the service (the ROS service path)
+   * @param {string} serviceType - the ROS service type (e.g. 'std_srvs/Empty')
+   * @param {object} additionalOptions - additional options to extend the service with
+   */
+  createService(connection, serviceName, serviceType, additionalOptions) {
     return new ROSLIB.Service(
       _.extend(
         {
           ros: connection,
           name: serviceName,
-          serviceType: serviceName
+          // Use the real ROS service type. Previously this was set to the
+          // service name, which is not a valid service type and broke calls.
+          serviceType: serviceType
         },
         additionalOptions
       )


### PR DESCRIPTION
Jira: https://hbpneurorobotics.atlassian.net/browse/EBR2-110

## ⚠️ Stacked PR — merge #12 (EBR2-108) first

This branch is stacked on top of **`EBR2-108-service-robustness` (PR #12)**, not
`development`. It **consumes the MQTT connection-state API added by EBR2-108**
(`mqtt-client-service` `getConnectionState()` / `isConnected()` plus the
`CONNECTION_STATE_CHANGED` / `RECONNECTING` / `ERROR` events).

**PR #12 (EBR2-108) MUST be merged into `development` before this PR.** Until
then this PR's diff will show the EBR2-108 commits as well; review only the
`[EBR2-110]` commits here. After #12 merges, rebase/retarget is clean.

## What this batch does

UX-feedback pass across the workbench, xpra, TF-editor and shell so long
operations, lost connections, and not-yet-available controls stop looking
broken or dead.

### Per-fix summary

1. **Workbench launch + lifecycle feedback** (`experiment-workbench.js` / `.css`)
   - Keep the toolbar disabled with a spinner from the moment **Initialize** is
     clicked until the sim reports its first MQTT status; a failed launch clears
     the spinner and reflects a **Failed** state (no more silent long launch).
   - Every lifecycle state (created / started / paused / completed / stopped /
     failed) maps to a clear label + status colour instead of the raw token.
2. **Workbench MQTT connection loss** (`experiment-workbench.js` / `.css`)
   - Subscribe to the EBR2-108 `CONNECTION_STATE_CHANGED` events and show a
     visible banner (reconnecting vs offline/error) so the dashboard no longer
     looks live after the broker drops.
3. **Xpra stream** (`xpra-view.js` / `.css`)
   - Loading overlay + error/retry fallback (watchdog timeout, since a dead
     cross-origin stream fires no `onError`) instead of a blank frame.
4. **TF editor** (`tf-editor.js` / `.css`)
   - Loading indicator while files/content load, a **Saving…** state that guards
     against double-clicks, and load/save failures surfaced via `DialogService`
     instead of being swallowed / only logged.
5. **Experiments overview tabs** (`experiments-overview.js` / `.css`)
   - The disabled *New Experiment* / *Model Libraries* tabs are marked
     "(coming soon)" with a tooltip so they read as intentional, not broken.
6. **Landing page** (`entry-page.js` / `.css`)
   - Responsive: the 3-column grid collapses to one column below 900px and the
     wrapper uses `min-height` instead of forcing `100vh`; the news iframe gets a
     loading state and an error/retry fallback.
7. **User menu** (`user-menu.js` / `.css`)
   - Resolves to a real name or falls back to an actionable **retry** after a
     timeout, instead of hanging on raw "pending …" forever.
8. **Import buttons** (`import-experiment-buttons.js` / `.css`)
   - Folder/zip/scan controls (and their hidden inputs) are disabled with a
     spinner while importing, preventing double-triggering.
9. **Experiment files viewer** (`experiment-files-viewer.js`)
   - Selecting an experiment with no local files now shows an explicit empty
     state instead of a silent no-op.
10. **Workbench CSS cleanup** (`experiment-workbench.css`)
    - Removed dead `simulation-view-*` / `simulation-tool-button` debug
      placeholders and switched the flexlayout tab from `overflow: scroll` to
      `auto` (no more always-on scrollbars).

### Scope

Only `experiment-workbench/**`, `xpra/**`, `tf-editor/**`,
`experiments-overview/**`, `entry-page/**`, `user-menu/**`,
`experiment-list/import-experiment-buttons.*`, `experiment-files-viewer/**` are
touched. No `src/services/**` (EBR2-108) and no `dialog/**` /
`experiment-list-element.js` / `nrp-header.js` (EBR2-109) — kept conflict-free.

## Verification (Docker `node:20`, repo mounted, `config.json` from
`config.json.sample.local`)

- `npm install` (honours `.npmrc` `legacy-peer-deps`) — OK
- `npm run build` (vite 5) — **OK**, built in ~6.5s (only pre-existing vendored
  `eval` warnings from `js-sha256`/`google-protobuf`)
- `npx jest --ci` — **15 suites passed; 109 passed, 14 skipped, 123 total**
  (unchanged from the EBR2-108 baseline)
- `eslint` on all changed files — clean (exit 0)
