### PR TITLE
[EBR2-111] Frontend cleanup: tests, drop @mui/styles, Bootstrap-3 leftovers, code-splitting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,9 @@ module.exports = {
   resetMocks: true,
   coverageReporters: ['html', 'cobertura'],
   collectCoverageFrom: ['src/services/**/*.js'],
+  // running-simulation-service, roslib-service and import-experiment-service are
+  // now exercised by their (un-skipped) suites, so they are collected again.
   coveragePathIgnorePatterns: [
-    'src/services/experiments/execution/running-simulation-service.js',
-    'src/services/roslib-service.js',
-    'src/services/experiments/files/import-experiment-service.js',
     'src/services/experiments/files/remote-experiment-files-service.js',
     'src/services/nrp-analytics-service.js'
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@mui/icons-material": "^5.16.7",
         "@mui/lab": "^5.0.0-alpha.173",
         "@mui/material": "^5.16.7",
-        "@mui/styles": "^5.16.7",
         "@mui/x-tree-view": "^6.17.0",
         "@uiw/react-codemirror": "4.12.4",
         "bootstrap": "^5",
@@ -4133,62 +4132,6 @@
         }
       }
     },
-    "node_modules/@mui/styles": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.18.0.tgz",
-      "integrity": "sha512-GDgFUfl2MMN8iGrYTuhJ0hHRoja2kVOlXnHb5d3BBQCHFxOBaAPDKQxaNkoAwRf/vBhhwXWDsJA2XlkNHUPBgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/hash": "^0.9.1",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.10.0",
-        "jss-plugin-camel-case": "^10.10.0",
-        "jss-plugin-default-unit": "^10.10.0",
-        "jss-plugin-global": "^10.10.0",
-        "jss-plugin-nested": "^10.10.0",
-        "jss-plugin-props-sort": "^10.10.0",
-        "jss-plugin-rule-value-function": "^10.10.0",
-        "jss-plugin-vendor-prefixer": "^10.10.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styles/node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styles/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@mui/system": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
@@ -7643,16 +7586,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/css-vendor": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -10392,12 +10325,6 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
@@ -10977,12 +10904,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
-      "license": "MIT"
     },
     "node_modules/is-interactive": {
       "version": "1.0.0",
@@ -13246,96 +13167,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/jss"
-      }
-    },
-    "node_modules/jss-plugin-camel-case": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-default-unit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-global": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-nested": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-props-sort": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -17365,12 +17196,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@mui/icons-material": "^5.16.7",
     "@mui/lab": "^5.0.0-alpha.173",
     "@mui/material": "^5.16.7",
-    "@mui/styles": "^5.16.7",
     "@mui/x-tree-view": "^6.17.0",
     "@uiw/react-codemirror": "4.12.4",
     "bootstrap": "^5",

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,33 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
+import Spinner from 'react-bootstrap/Spinner';
 
 import EntryPage from './components/entry-page/entry-page';
 import ErrorBoundary from './components/error-boundary/error-boundary';
 import ErrorDialog from './components/dialog/error-dialog.js';
-import ExperimentsOverview from './components/experiments-overview/experiments-overview';
-import ExperimentWorkbench from './components/experiment-workbench/experiment-workbench';
-// import SimulationView from './components/simulation-view/simulation-view';
 import NotificationDialog from './components/dialog/notification-dialog.js';
 import MqttClientService from './services/mqtt-client-service';
+
+// Route-level code splitting. The experiments overview and the (heavy)
+// experiment workbench — the latter pulls in flexlayout, the CodeMirror TF
+// editor and the xpra viewer — are loaded on demand so they no longer inflate
+// the initial bundle. The entry page stays eager as the default landing route.
+const ExperimentsOverview = lazy(() => import('./components/experiments-overview/experiments-overview'));
+const ExperimentWorkbench = lazy(() => import('./components/experiment-workbench/experiment-workbench'));
+// import SimulationView from './components/simulation-view/simulation-view';
+
+const RouteFallback = () => (
+  <div
+    className='route-loading'
+    role='status'
+    aria-live='polite'
+    style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+    <Spinner animation='border' role='status' aria-hidden='true' />
+    <span style={{ marginLeft: 12 }}>Loading…</span>
+  </div>
+);
 
 class App extends React.Component {
 
@@ -25,14 +42,16 @@ class App extends React.Component {
           <ErrorDialog />
           <NotificationDialog/>
           <BrowserRouter>
-            <Routes>
-              <Route path='/experiments-overview' element={<ExperimentsOverview/>} />
-              <Route path='/experiment/:experimentID' element={<ExperimentWorkbench/>} />
-              {/* <Route path='/simulation-view/:serverIP/:simulationID' element={<SimulationView/>} /> */}
-              {/* Catch-all keeps the v5 behaviour where the non-exact '/' route
-                  rendered the entry page for the root and any unmatched path. */}
-              <Route path='*' element={<EntryPage cookies={this.props.cookies}/>} />
-            </Routes>
+            <Suspense fallback={<RouteFallback />}>
+              <Routes>
+                <Route path='/experiments-overview' element={<ExperimentsOverview/>} />
+                <Route path='/experiment/:experimentID' element={<ExperimentWorkbench/>} />
+                {/* <Route path='/simulation-view/:serverIP/:simulationID' element={<SimulationView/>} /> */}
+                {/* Catch-all keeps the v5 behaviour where the non-exact '/' route
+                    rendered the entry page for the root and any unmatched path. */}
+                <Route path='*' element={<EntryPage cookies={this.props.cookies}/>} />
+              </Routes>
+            </Suspense>
           </BrowserRouter>
         </div>
       </ErrorBoundary>

--- a/src/components/experiment-list/experiment-list-element.css
+++ b/src/components/experiment-list/experiment-list-element.css
@@ -15,14 +15,6 @@
   background: linear-gradient( to right, rgba(255, 255, 255, 0.8) 0%, rgba(245, 245, 245, 0.8) 100%);
 }
 
-.flex-container.hover-wizard {
-  background: linear-gradient( to right, rgba(255, 255, 255, 0.8) 0%, rgba(230, 239, 255, 0.8) 100%);
-}
-
-.flex-container.selected-wizard {
-  background: linear-gradient( to right, rgba(255, 255, 255, 0.8) 0%, rgba(230, 239, 255, 0.8) 100%);
-}
-
 .flex-container.left-right {
   flex-direction: row;
 }
@@ -66,13 +58,6 @@
 
 .list-entry-middle {
   flex: 1;
-}
-
-.list-entry-running {
-  font-size: 12px;
-  font-style: italic;
-  color: #555555;
-  padding-left: 10px;
 }
 
 .list-entry-buttons {

--- a/src/components/experiment-list/experiment-list-element.js
+++ b/src/components/experiment-list/experiment-list-element.js
@@ -258,7 +258,7 @@ class ExperimentListElement extends React.Component {
             <div className='list-entry-buttons flex-container' >
               <div className='btn-group' role='group' >
                 {exp.rights.launch ?
-                  <Button className="nrp-btn btn-default"
+                  <Button className="nrp-btn"
                     onClick={() => {
                       this.openExperimentWorkbench(exp.id);
                     }}
@@ -271,26 +271,26 @@ class ExperimentListElement extends React.Component {
                 TODO: [NRRPLT-8682]
                 Change Files icon and make the file aditor to be the opened tab in the experiment-workbench
                 {<Link to={'/experiment/' + exp.id}
-                  className="nrp-btn btn-default" disabled={this.isLaunchDisabled()}>
+                  className="nrp-btn" disabled={this.isLaunchDisabled()}>
                   <AiFillExperiment className='icon' />Files
                 </Link>
                 } */}
 
                 {/*exp.rights.launch && config.brainProcesses > 1 ?
-                  <button className='nrp-btn btn-default'>
+                  <button className='nrp-btn'>
                     <RiPlayLine className='icon' />Launch in Single Process Mode
                   </button>
                   : null*/}
 
                 {/*exp.rights.launch && this.props.availableServers.length > 1 ?
-                  <button className='nrp-btn btn-default' >
+                  <button className='nrp-btn' >
                     <RiPlayList2Fill className='icon' />Launch Multiple
                   </button>
                 : null*/}
 
                 {/* isPrivateExperiment */}
                 {exp.rights.delete ?
-                  <Button className='nrp-btn btn-default'
+                  <Button className='nrp-btn'
                     variant='warning'
                     onClick={() => {
                       this.showRemoveDialog(true);
@@ -302,7 +302,7 @@ class ExperimentListElement extends React.Component {
 
                 {/* Records button */}
                 {/* {exp.rights.launch ?
-                  <Button className='nrp-btn btn-default'
+                  <Button className='nrp-btn'
                     variant='secondary'
                     disabled={true}>
                     {this.state.showRecordings ?
@@ -315,7 +315,7 @@ class ExperimentListElement extends React.Component {
 
                 {/* Export button */}
                 {exp.rights.launch ? (
-                  <Button className='nrp-btn btn-default'
+                  <Button className='nrp-btn'
                     variant='secondary'
                     onClick={async () => {
                       this.setState({ exportInProgress: true });
@@ -334,7 +334,7 @@ class ExperimentListElement extends React.Component {
 
                 {/* Simulations button */}
                 {exp.rights.launch && exp.joinableServers.length > 0 ?
-                  <Button className='nrp-btn btn-default'
+                  <Button className='nrp-btn'
                     variant='primary'
                     onClick={() => {
                       this.setState({ showSimDetails: !this.state.showSimDetails });
@@ -348,7 +348,7 @@ class ExperimentListElement extends React.Component {
                   : null}
 
                 {/* Clone button */}
-                <Button className='nrp-btn btn-default' disabled={!exp.rights.clone}
+                <Button className='nrp-btn' disabled={!exp.rights.clone}
                   variant='secondary'
                   onClick={async () => {
                     this.setState({ cloneInProgress: true });
@@ -376,7 +376,7 @@ class ExperimentListElement extends React.Component {
 
                 {/* Shared button */}
                 {exp.rights.launch ?
-                  <Button className='nrp-btn btn-default'
+                  <Button className='nrp-btn'
                     variant='secondary'
                     disabled={true}>
                     <FaShareAlt className='icon' />Share

--- a/src/components/experiment-list/experiment-list-element.js
+++ b/src/components/experiment-list/experiment-list-element.js
@@ -15,7 +15,7 @@ import ExperimentStorageService from '../../services/experiments/files/experimen
 import RemoveExperimentDialog from './remove-experiment-dialog';
 
 import SimulationDetails from './simulation-details';
-import ExperimentOverview from '../experiments-overview/experiments-overview.js';
+import { TAB_INDEX } from '../experiments-overview/experiments-overview-constants.js';
 import timeDDHHMMSS from '../../utility/time-filter';
 
 import './experiment-list-element.css';
@@ -365,7 +365,7 @@ class ExperimentListElement extends React.Component {
                     await ExperimentStorageService.instance.getExperiments(true).then(() => {
                       this.setState({cloneInProgress: false});
                     });
-                    this.props.selectExperimentOverviewTab(ExperimentOverview.CONSTANTS.TAB_INDEX.MY_EXPERIMENTS);
+                    this.props.selectExperimentOverviewTab(TAB_INDEX.MY_EXPERIMENTS);
                   }}
                 >
                   {this.state.cloneInProgress

--- a/src/components/experiment-list/simulation-details.js
+++ b/src/components/experiment-list/simulation-details.js
@@ -86,7 +86,7 @@ class SimulationDetails extends React.Component {
                 <button /*analytics-on analytics-event="Join" analytics-category="Experiment"
                   ng-click="(simulation.runningSimulation.state === STATE.CREATED) ||
                     simulation.stopping || joinExperiment(simulation, exp);"*/
-                  type="button" className='nrp-btn btn-default'
+                  type="button" className='nrp-btn'
                   disabled={this.isJoinDisabled(simulation)}
                   onClick={() => {
                     this.joinSimulation(simulation);
@@ -106,7 +106,7 @@ class SimulationDetails extends React.Component {
                       console.error(err.toString());
                     };
                   }}
-                  type="button" className='nrp-btn btn-default'
+                  type="button" className='nrp-btn'
                   disabled={this.state.shutdownDisabled}
                   title={this.state.titleButtonShutdown}>
                   <FaStop className='icon' />Shutdown
@@ -120,7 +120,7 @@ class SimulationDetails extends React.Component {
         {/* TODO: [NRRPLT-8773] Add Stop All button */}
         {/* <div className='table-row'>
           <div className='table-column-last'>
-            <button className='nrp-btn btn-default'>
+            <button className='nrp-btn'>
               <FaStopCircle className='icon' />Stop All
             </button>
           </div>

--- a/src/components/experiment-workbench/__tests__/leave-workbench-dialog.test.js
+++ b/src/components/experiment-workbench/__tests__/leave-workbench-dialog.test.js
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import LeaveWorkbenchDialog from '../leave-workbench-dialog';
+
+// The leave/exit dialog is the user-facing side of the workbench state handling
+// hardened in EBR2-100/108: whether the simulation can still be shut down
+// (shutdownDisabled) must drive both the message and the Shutdown control.
+describe('LeaveWorkbenchDialog', () => {
+  const renderDialog = (props = {}) => {
+    const handlers = {
+      setVisibility: jest.fn(),
+      leaveWorkbench: jest.fn(),
+      shutdownSimulation: jest.fn()
+    };
+    render(
+      <LeaveWorkbenchDialog
+        visible
+        shutdownDisabled={false}
+        {...handlers}
+        {...props}
+      />
+    );
+    return handlers;
+  };
+
+  it('stays hidden until it is made visible', () => {
+    render(
+      <LeaveWorkbenchDialog
+        visible={false}
+        shutdownDisabled={false}
+        setVisibility={jest.fn()}
+        leaveWorkbench={jest.fn()}
+        shutdownSimulation={jest.fn()}
+      />
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('offers both leave and shutdown when the simulation can still be shut down', async () => {
+    const handlers = renderDialog({ shutdownDisabled: false });
+
+    expect(await screen.findByText(/leave or shutdown the simulation/i)).toBeInTheDocument();
+
+    const shutdown = screen.getByRole('button', { name: 'Shutdown' });
+    expect(shutdown).toBeEnabled();
+    fireEvent.click(shutdown);
+    expect(handlers.shutdownSimulation).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }));
+    expect(handlers.leaveWorkbench).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers leave only and disables shutdown for a finalized simulation', async () => {
+    const handlers = renderDialog({ shutdownDisabled: true });
+
+    expect(await screen.findByText(/leave the simulation/i)).toBeInTheDocument();
+    expect(screen.queryByText(/shutdown the simulation/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Shutdown' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }));
+    expect(handlers.leaveWorkbench).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/experiment-workbench/experiment-workbench.js
+++ b/src/components/experiment-workbench/experiment-workbench.js
@@ -20,14 +20,11 @@ import '../../../node_modules/flexlayout-react/style/light.css';
 import './experiment-workbench.css';
 
 
-import withStyles from '@mui/styles/withStyles';
-import { ThemeProvider } from '@mui/styles';
-import { createTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import clsx from 'clsx';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import PropTypes from 'prop-types';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -86,21 +83,43 @@ const jsonBaseLayout = {
 
 // TODO: Unify styles with css or mui styles
 const drawerWidth = 240;
-const useStyles = theme => ({
-  root: {
-    display: 'flex'
-  },
-  toolbar: {
+
+// Stable class names applied to the workbench elements. The rules for each are
+// declared on the `Root` styled component below (MUI v5 `styled`, replacing the
+// removed deprecated JSS bridge). `styled` from @mui/material/styles resolves
+// against MUI's full default theme, so no explicit ThemeProvider is needed for
+// theme.mixins/zIndex/transitions/spacing/breakpoints.
+const classes = {
+  toolbar: 'ExpWb-toolbar',
+  toolbarIcon: 'ExpWb-toolbarIcon',
+  appBar: 'ExpWb-appBar',
+  appBarShift: 'ExpWb-appBarShift',
+  menuButton: 'ExpWb-menuButton',
+  menuButtonHidden: 'ExpWb-menuButtonHidden',
+  controlButton: 'ExpWb-controlButton',
+  title: 'ExpWb-title',
+  drawerPaper: 'ExpWb-drawerPaper',
+  drawerPaperClose: 'ExpWb-drawerPaperClose',
+  appBarSpacer: 'ExpWb-appBarSpacer',
+  content: 'ExpWb-content',
+  container: 'ExpWb-container',
+  controlContainer: 'ExpWb-controlContainer',
+  contentContainer: 'ExpWb-contentContainer'
+};
+
+const Root = styled('div')(({ theme }) => ({
+  display: 'flex',
+  [`& .${classes.toolbar}`]: {
     paddingRight: 24 // keep right padding when drawer closed
   },
-  toolbarIcon: {
+  [`& .${classes.toolbarIcon}`]: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     padding: '0 8px',
     ...theme.mixins.toolbar
   },
-  appBar: {
+  [`& .${classes.appBar}`]: {
     position: 'absolute',
     zIndex: theme.zIndex.drawer + 1,
     transition: theme.transitions.create(['width', 'margin'], {
@@ -108,7 +127,7 @@ const useStyles = theme => ({
       duration: theme.transitions.duration.leavingScreen
     })
   },
-  appBarShift: {
+  [`& .${classes.appBarShift}`]: {
     marginLeft: drawerWidth,
     width: `calc(100% - ${drawerWidth}px)`,
     transition: theme.transitions.create(['width', 'margin'], {
@@ -116,22 +135,19 @@ const useStyles = theme => ({
       duration: theme.transitions.duration.enteringScreen
     })
   },
-  menuButton: {
+  [`& .${classes.menuButton}`]: {
     marginRight: 36
   },
-  menuButtonHidden: {
+  [`& .${classes.menuButtonHidden}`]: {
     display: 'none'
   },
-  controlButton: {
-    borderWidth: '0',
-    shape: {
-      borderRadius: 0
-    }
+  [`& .${classes.controlButton}`]: {
+    borderWidth: '0'
   },
-  title: {
+  [`& .${classes.title}`]: {
     flexGrow: 1
   },
-  drawerPaper: {
+  [`& .${classes.drawerPaper}`]: {
     position: 'relative',
     whiteSpace: 'nowrap',
     width: drawerWidth,
@@ -140,7 +156,7 @@ const useStyles = theme => ({
       duration: theme.transitions.duration.enteringScreen
     })
   },
-  drawerPaperClose: {
+  [`& .${classes.drawerPaperClose}`]: {
     overflowX: 'hidden',
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
@@ -151,21 +167,21 @@ const useStyles = theme => ({
       width: theme.spacing(9)
     }
   },
-  appBarSpacer: theme.mixins.toolbar,
-  content: {
+  [`& .${classes.appBarSpacer}`]: theme.mixins.toolbar,
+  [`& .${classes.content}`]: {
     position: 'relative',
     flexGrow: 1,
     height: '100vh',
     overflow: 'hidden'
   },
-  container: {
+  [`& .${classes.container}`]: {
     position: 'relative',
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(0),
     direction: 'column',
     display: 'flex'
   },
-  controlContainer: {
+  [`& .${classes.controlContainer}`]: {
     height: 50,
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
@@ -178,14 +194,14 @@ const useStyles = theme => ({
     alignItems: 'center'
   },
   // TODO: Fix vertical filling
-  contentContainer: {
+  [`& .${classes.contentContainer}`]: {
     height: '80vh',
     padding: theme.spacing(1),
     display: 'flex',
     overflow: 'auto',
     flexDirection: 'column'
   }
-});
+}));
 
 
 class ExperimentWorkbench extends React.Component {
@@ -544,9 +560,8 @@ class ExperimentWorkbench extends React.Component {
   }
 
   render() {
-    const { classes } = this.props;
     return (
-      <div className={classes.root}>
+      <Root>
         <CssBaseline />
         <AppBar position='absolute' className={clsx(classes.appBar, this.state.drawerOpen && classes.appBarShift)}>
           <Toolbar className={classes.toolbar}>
@@ -727,28 +742,13 @@ class ExperimentWorkbench extends React.Component {
             </Grid>
           </Grid>
         </main>
-      </div>
+      </Root>
     );
   }
 
 }
 
-ExperimentWorkbench.propTypes = {
-  classes: PropTypes.object.isRequired
-};
-
-// MUI v5's @mui/styles bridge ships an empty default theme, so the JSS
-// styles above (theme.mixins/zIndex/transitions/spacing/breakpoints) need a
-// full theme supplied via the @mui/styles ThemeProvider.
-const muiTheme = createTheme();
-const StyledExperimentWorkbench = withStyles(useStyles)(ExperimentWorkbench);
-const ThemedExperimentWorkbench = props => (
-  <ThemeProvider theme={muiTheme}>
-    <StyledExperimentWorkbench {...props} />
-  </ThemeProvider>
-);
-
-export default withRouter(withCookies(ThemedExperimentWorkbench));
+export default withRouter(withCookies(ExperimentWorkbench));
 
 ExperimentWorkbench.CONSTANTS = Object.freeze({
   INTERVAL_INTERNAL_UPDATE_MS: 1000

--- a/src/components/experiments-overview/experiments-overview-constants.js
+++ b/src/components/experiments-overview/experiments-overview-constants.js
@@ -1,0 +1,13 @@
+// Tab indices for the experiments-overview tabs. Kept in a standalone module so
+// leaf components (e.g. experiment-list-element) can reference them without
+// statically importing the heavy ExperimentsOverview component — that static
+// import would otherwise pin the whole overview subtree into the main bundle and
+// defeat the route-level code splitting in App.js.
+export const TAB_INDEX = Object.freeze({
+  MY_EXPERIMENTS: 0,
+  NEW_EXPERIMENT: 1,
+  MODEL_LIBRARIES: 2,
+  EXPERIMENT_FILES: 3,
+  TEMPLATES: 4,
+  RUNNING_SIMULATIONS: 5
+});

--- a/src/components/experiments-overview/experiments-overview.js
+++ b/src/components/experiments-overview/experiments-overview.js
@@ -13,19 +13,13 @@ import ImportExperimentButtons from '../experiment-list/import-experiment-button
 import ExperimentList from '../experiment-list/experiment-list.js';
 import NrpHeader from '../nrp-header/nrp-header.js';
 import ExperimentFilesViewer from '../experiment-files-viewer/experiment-files-viewer.js';
+import { TAB_INDEX } from './experiments-overview-constants.js';
 
 import './experiments-overview.css';
 
 export default class ExperimentsOverview extends React.Component {
   static CONSTANTS = {
-    TAB_INDEX: {
-      MY_EXPERIMENTS: 0,
-      NEW_EXPERIMENT: 1,
-      MODEL_LIBRARIES: 2,
-      EXPERIMENT_FILES: 3,
-      TEMPLATES: 4,
-      RUNNING_SIMULATIONS: 5
-    }
+    TAB_INDEX
   };
 
   constructor(props) {

--- a/src/components/main.css
+++ b/src/components/main.css
@@ -1,6 +1,16 @@
+/* Shared button styling. The former Bootstrap-3 companion class was removed (it
+   is undefined in Bootstrap 5); react-bootstrap <Button>s keep their colours
+   from the `variant` prop, while the plain <button>s rely on these rules alone.
+   Only layout/affordance is set here so it never overrides a variant's colour. */
 .nrp-btn {
     padding: 5px 10px 5px 10px;
     border: 1px solid lightgray;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.nrp-btn:disabled {
+    cursor: not-allowed;
 }
 
 .nrp-btn-small {

--- a/src/services/__tests__/roslib-service.test.js
+++ b/src/services/__tests__/roslib-service.test.js
@@ -63,7 +63,7 @@ describe('RoslibService (EBR2-108)', () => {
   });
 });
 
-describe.skip('RoslibService', () => {
+describe('RoslibService', () => {
   test('makes sure that invoking the constructor fails with the right message', () => {
     expect(() => {
       new RoslibService();
@@ -79,17 +79,12 @@ describe.skip('RoslibService', () => {
     expect(instance1).toBe(instance2);
   });
 
-  test('can provide ROS connections', () => {
-    jest.spyOn(ROSLIB, 'Ros').mockReturnValue({});
-    let connection1 = RoslibService.instance.getConnection('test-ros-ws-url');
-    let connection2 = RoslibService.instance.getConnection('test-ros-ws-url');
-    expect(connection1).toBe(connection2);
-    expect(ROSLIB.Ros).toHaveBeenCalledTimes(1);
-  });
+  // Connection caching is covered by the EBR2-108 suite above; the legacy test
+  // here treated getConnection as synchronous (it is now async), so it is dropped.
 
   test('can create ROS topics with additional options', () => {
     let mockTopic = {};
-    jest.spyOn(ROSLIB, 'Topic').mockReturnValue(mockTopic);
+    ROSLIB.Topic.mockImplementation(() => mockTopic);
     let rosConnection = {};
     let topicName = 'test-topic-name';
     let messageType = 'test-message-type';
@@ -111,7 +106,6 @@ describe.skip('RoslibService', () => {
   });
 
   test('has a shortcut for creating string topics', () => {
-    jest.spyOn(ROSLIB, 'Topic').mockImplementation();
     let rosConnection = {};
     let topicName = 'test-topic-name';
 
@@ -124,25 +118,7 @@ describe.skip('RoslibService', () => {
     expect(ROSLIB.Topic).toHaveBeenCalledWith(expectedTopicOptions);
   });
 
-  test('can create ROS services with additional options', () => {
-    let mockService = {};
-    jest.spyOn(ROSLIB, 'Service').mockReturnValue(mockService);
-    let rosConnection = {};
-    let serviceName = 'test-topic-name';
-    let additionalOptions = {
-      something: {},
-      else: true
-    };
-
-    let service = RoslibService.instance.createService(rosConnection, serviceName, additionalOptions);
-    expect(service).toBe(mockService);
-    let expectedTopicOptions = {
-      ros: rosConnection,
-      name: serviceName,
-      serviceType: serviceName,
-      something: additionalOptions.something,
-      else: additionalOptions.else
-    };
-    expect(ROSLIB.Service).toHaveBeenCalledWith(expectedTopicOptions);
-  });
+  // createService is covered by the EBR2-108 suite above; the legacy test here
+  // asserted the old buggy signature (serviceType defaulted to the name), which
+  // no longer holds after the EBR2-108 fix, so it is dropped.
 });

--- a/src/services/experiments/execution/__tests__/running-simulation-service.test.js
+++ b/src/services/experiments/execution/__tests__/running-simulation-service.test.js
@@ -4,12 +4,10 @@
 import '@testing-library/jest-dom';
 import 'jest-fetch-mock';
 
-import MockAvailableServers from '../../../../mocks/mock_available-servers.json';
 import MockSimulations from '../../../../mocks/mock_simulations.json';
 
 import RunningSimulationService from '../running-simulation-service.js';
 import DialogService from '../../../dialog-service';
-import RoslibService from '../../../roslib-service';
 import { EXPERIMENT_STATE } from '../../experiment-constants.js';
 
 jest.setTimeout(10000);
@@ -18,7 +16,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe.skip('RunningSimulationService', () => {
+describe('RunningSimulationService', () => {
 
   test('makes sure that invoking the constructor fails with the right message', () => {
     expect(() => {
@@ -37,20 +35,22 @@ describe.skip('RunningSimulationService', () => {
 
   test('verifies whether a simulation is ready', async () => {
     let mockSimulationList = JSON.parse(JSON.stringify(MockSimulations));
+    // The legacy suite drove state transitions with EXPERIMENT_STATE.HALTED /
+    // .INITIALIZED, which do not exist in EXPERIMENT_STATE (both undefined), so
+    // the "bad state" leg wrongly matched the ready branch. Use real states:
+    // CREATED (pending) -> PAUSED (ready) and FAILED for the terminal reject.
     jest.spyOn(RunningSimulationService.instance, 'httpRequestGET').mockImplementation(() => {
-      if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 1) {
+      const call = RunningSimulationService.instance.httpRequestGET.mock.calls.length;
+      if (call === 1) {
         mockSimulationList[0].state = EXPERIMENT_STATE.CREATED; // state pending
       }
-      else if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 2) {
-        mockSimulationList[0].state = EXPERIMENT_STATE.PAUSED; // state ok
+      else if (call === 3) {
+        mockSimulationList[0].state = EXPERIMENT_STATE.FAILED; // terminal state
       }
-      else if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 3) {
-        mockSimulationList[0].state = EXPERIMENT_STATE.HALTED; // state bad
-      }
-      else if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 4) {
+      else if (call === 4) {
         return Promise.reject('mock simulation GET error'); // general error
       }
-      else if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 5) {
+      else {
         mockSimulationList[0].state = EXPERIMENT_STATE.PAUSED; // state ok
       }
 
@@ -61,25 +61,29 @@ describe.skip('RunningSimulationService', () => {
       });
     });
 
+    // A tiny interval keeps the polling loop fast and deterministic.
+    const options = { interval: 1, maxAttempts: 10 };
+
     // call 1 (created) => continue checking & call 2 (paused) => resolved successfully
     let simReady = RunningSimulationService.instance
-      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID);
+      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID, options);
     await expect(simReady).resolves.toEqual(mockSimulationList[0]);
 
-    // call 3 (halted) => rejected with state
+    // call 3 (failed) => rejected with the terminal state
     simReady = RunningSimulationService.instance
-      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID);
-    await expect(simReady).rejects.toEqual(EXPERIMENT_STATE.HALTED);
+      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID, options);
+    await expect(simReady).rejects.toEqual(EXPERIMENT_STATE.FAILED);
 
     // call 4 (error) => rejected with error
     simReady = RunningSimulationService.instance
-      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID);
+      .simulationReady('mock-server-url', mockSimulationList[0].creationUniqueID, options);
     await expect(simReady).rejects.toEqual('mock simulation GET error');
 
     // call 5 (state ok but wrong creation id) => rejected because of wrong creation ID
+    // EBR2-108: a mismatch is now a terminal Error, not a silent undefined reject.
     simReady = RunningSimulationService.instance
-      .simulationReady('mock-server-url', 'wrong-creation-id');
-    await expect(simReady).rejects.toEqual(undefined);
+      .simulationReady('mock-server-url', 'wrong-creation-id', options);
+    await expect(simReady).rejects.toThrow('creationUniqueID mismatch');
   });
 
   test('can retrieve the state of a simulation', async () => {
@@ -110,26 +114,26 @@ describe.skip('RunningSimulationService', () => {
   });
 
   test('can set the state of a simulation', async () => {
-    let returnValuePUT = undefined;
+    let returnValuePUT = { state: EXPERIMENT_STATE.PAUSED };
     jest.spyOn(DialogService.instance, 'simulationError').mockImplementation();
+    // updateState issues a PUT and returns the parsed body, so the mock must key
+    // off httpRequestPUT (the previous httpRequestGET.mock reference threw) and
+    // hand back a Response-like object exposing json().
     jest.spyOn(RunningSimulationService.instance, 'httpRequestPUT').mockImplementation(() => {
-      if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 1) {
-        returnValuePUT = {};
+      if (RunningSimulationService.instance.httpRequestPUT.mock.calls.length === 1) {
+        return Promise.resolve({ json: () => returnValuePUT });
       }
-      else if (RunningSimulationService.instance.httpRequestGET.mock.calls.length === 2) {
-        return Promise.reject();
-      }
-
-      return Promise.resolve(returnValuePUT);
+      return Promise.reject();
     });
 
     // call 1 => proper return
     let returnValue = await RunningSimulationService.instance.updateState('test-url', 1, EXPERIMENT_STATE.PAUSED);
     expect(returnValue).toBe(returnValuePUT);
 
-    // call 2 => rejected
+    // call 2 => rejected => error surfaced and a FAILED state returned
     returnValue = await RunningSimulationService.instance.updateState('test-url', 1, EXPERIMENT_STATE.PAUSED);
     expect(DialogService.instance.simulationError).toHaveBeenCalled();
+    expect(returnValue).toEqual({ state: EXPERIMENT_STATE.FAILED });
   });
 });
 

--- a/src/services/experiments/files/__tests__/import-experiment-service.test.js
+++ b/src/services/experiments/files/__tests__/import-experiment-service.test.js
@@ -9,8 +9,7 @@ import ImportExperimentService from '../import-experiment-service';
 import MockScanStorageResponse from '../../../../mocks/mock_scan_storage_response.json';
 import MockZipResponses from '../../../../mocks/mock_zip_responses.json';
 
-// TODO: [NRRPLT-8721] restore experiment import funtionality
-describe.skip('ImportExperimentService', () => {
+describe('ImportExperimentService', () => {
 
   test('makes sure that invoking the constructor fails with the right message', () => {
     expect(() => {
@@ -22,7 +21,15 @@ describe.skip('ImportExperimentService', () => {
   });
 
   test('makes sure zip responses are encapsulated in an object', async () => {
-    let importZipResponses = {zipBaseFolderName:['0', '0'], destFolderName:['1', '2'], numberOfZips: 2};
+    // EBR2-108: getImportZipResponses now also collects newExpName (from each
+    // response's newName). The mock responses omit newName, so those entries are
+    // undefined, but the key is present in the returned object.
+    let importZipResponses = {
+      zipBaseFolderName: ['0', '0'],
+      destFolderName: ['1', '2'],
+      newExpName: [undefined, undefined],
+      numberOfZips: 2
+    };
     expect(await ImportExperimentService.instance.getImportZipResponses(
       MockZipResponses.map((response) => new Response(JSON.stringify(response))))).toStrictEqual(importZipResponses);
   });


### PR DESCRIPTION
Frontend cleanup tail: revive deferred tests, drop the last deprecated JSS
bridge, remove Bootstrap-3 leftovers, and code-split the heavy routes.

Ticket: https://hbpneurorobotics.atlassian.net/browse/EBR2-111

Base: `development` (modern stack — Vite / React 18 / react-router v6 / MUI v5 /
Bootstrap 5 / Node 20, with the EBR2-108/109/110 UX-a11y wave merged).

## Concern 1 — Test coverage
Un-skipped and repaired the three `describe.skip` service suites left after
EBR2-108:
- **running-simulation-service**: fixed the `updateState` mock (it referenced
  `httpRequestGET.mock` and returned a value with no `json()`); the
  `simulationReady` case now drives real `EXPERIMENT_STATE` values (the legacy
  suite used non-existent `HALTED`/`INITIALIZED` constants that resolve to
  `undefined`, so the "bad state" leg wrongly matched the ready branch), uses a
  tiny poll interval, and expects the EBR2-108 mismatch `Error`.
- **roslib-service**: relies on the file's existing `jest.mock('roslib')` so no
  real socket opens; dropped the `getConnection` and `createService` cases that
  duplicated the EBR2-108 suite and asserted the old (now-fixed)
  synchronous/`serviceType` API (removed with an in-file reason, not re-skipped).
- **import-experiment-service**: adjusted the expectation to the EBR2-108
  behaviour (the `newExpName` key is now present).

Re-enabled coverage collection for those three services in `jest.config.js`.
Also added an RTL test for the workbench leave/shutdown dialog (builds on the
EBR2-109 dialog RTL setup): `shutdownDisabled` must switch the message and
disable the Shutdown control, and the buttons must fire their callbacks.

**Jest: 115 passed / 14 skipped (17 suites) → 130 passed / 0 skipped (18 suites).**

## Concern 2 — Drop the `@mui/styles` bridge
The experiment workbench was the last component on the deprecated `@mui/styles`
`withStyles` JSS bridge (EBR2-62 leftover). Migrated it to a MUI v5 `styled()`
`Root` component that declares the former rules as nested class selectors, and
dropped the `withStyles` / bridge `ThemeProvider` / `createTheme` scaffolding and
the now-unused `classes` prop. `styled()` from `@mui/material/styles` resolves
against MUI's full default theme, so the explicit provider the bridge required
(its default theme was empty) is gone. Removed `@mui/styles` from `package.json`;
the JSS subtree drops from the lockfile.

`grep -rn "@mui/styles\|withStyles\|makeStyles" src/` → **empty**.

## Concern 3 — Bootstrap-3 leftovers
`btn-default` is a Bootstrap-3 class with no definition under Bootstrap 5 (and
none in the project CSS), so it was inert on every button. Removed it from the
experiment-list and simulation-details buttons; react-bootstrap `<Button>`s keep
their colours from the `variant` prop. Reconciled `.nrp-btn` (the sole styling
for the plain `<button>`s, which have no `.btn` base) with a border-radius and
pointer/disabled cursors, scoped to layout so it never overrides a variant's
colour. (No `glyphicon` remained in `src/`.)

`grep -rn "glyphicon\|btn-default" src/` → **empty**.

## Concern 4 — Dead CSS / bundle
- Removed the unreferenced jquery-era `.hover-wizard` / `.selected-wizard`
  (old experiment-wizard leftovers) and `.list-entry-running` CSS rules.
- Route-level code splitting (React.lazy + Suspense): the experiment workbench
  (flexlayout + CodeMirror TF editor + xpra viewer) and the experiments overview
  now load on demand, with the entry page kept eager as the landing route. The
  router-v6 route config is otherwise unchanged. Extracted the overview
  `TAB_INDEX` into a standalone constants module so `experiment-list-element` no
  longer statically imports the overview component (that import previously pinned
  the whole overview subtree into the main bundle and blocked its split).

Initial JS bundle **~2.19 MB → ~1.25 MB**, with `experiment-workbench` (~613 kB)
and `experiments-overview` (~201 kB) emitted as separate on-demand chunks. Vite
still prints the >500 kB advisory for the vendor-dominated `index` chunk and the
workbench chunk; fully silencing it would need vendor `manualChunks`, kept out of
this conservative pass.

## Verification (Docker `node:20`, repo mounted, `src/config.json` from sample, not committed)
- `npm install` (honours `.npmrc` `legacy-peer-deps`) — OK.
- `npm run build` (vite) — OK; lazy chunks present (`experiment-workbench`,
  `experiments-overview`, `react-tabs`).
- `npx jest --ci` — **130 passed, 0 skipped, 18 suites** (baseline 115/14).
- `eslint` — clean on all changed files.
- greps for `@mui/styles|withStyles|makeStyles` and `glyphicon|btn-default` in
  `src/` are both empty.
